### PR TITLE
Feature/distributions part4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ if( dryad.python )
       python/src/ReferenceFrame.python.cpp
       python/src/TabulatedCrossSection.python.cpp
       python/src/TabulatedMultiplicity.python.cpp
+      python/src/TabulatedAverageEnergy.python.cpp
       python/src/LegendreAngularDistribution.python.cpp
       python/src/LegendreAngularDistributions.python.cpp
       python/src/TabulatedAngularDistribution.python.cpp

--- a/cmake/unit_testing.cmake
+++ b/cmake/unit_testing.cmake
@@ -29,6 +29,7 @@ endfunction()
 add_subdirectory( src/dryad/id/ElementID/test )
 
 add_subdirectory( src/dryad/TabulatedMultiplicity/test )
+add_subdirectory( src/dryad/TabulatedAverageEnergy/test )
 add_subdirectory( src/dryad/LegendreAngularDistribution/test )
 add_subdirectory( src/dryad/LegendreAngularDistributions/test )
 add_subdirectory( src/dryad/TabulatedAngularDistribution/test )

--- a/cmake/unit_testing_python.cmake
+++ b/cmake/unit_testing_python.cmake
@@ -25,6 +25,7 @@ message( STATUS "Adding dryad Python unit testing" )
 add_python_test( id.ElementID id/Test_dryad_id_ElementID.py )
 
 add_python_test( TabulatedMultiplicity         Test_dryad_TabulatedMultiplicity.py )
+add_python_test( TabulatedAverageEnergy        Test_dryad_TabulatedAverageEnergy.py )
 add_python_test( LegendreAngularDistribution   Test_dryad_LegendreAngularDistribution.py )
 add_python_test( LegendreAngularDistributions  Test_dryad_LegendreAngularDistributions.py )
 add_python_test( TabulatedAngularDistribution  Test_dryad_TabulatedAngularDistribution.py )

--- a/python/src/ReactionProduct.python.cpp
+++ b/python/src/ReactionProduct.python.cpp
@@ -64,6 +64,12 @@ void wrapReactionProduct( python::module& module, python::module& ) {
   )
   .def_property_readonly(
 
+    "average_energy",
+    &Component::averageEnergy,
+    "The average reaction product energy"
+  )
+  .def_property_readonly(
+
     "distribution_data",
     &Component::distributionData,
     "The distribution data"
@@ -73,6 +79,13 @@ void wrapReactionProduct( python::module& module, python::module& ) {
     "is_linearised",
     &Component::isLinearised,
     "Flag indicating whether or not the reaction product is linearised"
+  )
+  .def_property_readonly(
+
+    "has_average_energy",
+    &Component::hasAverageEnergy,
+    "Flag indicating whether or not the reaction product has average reaction "
+    "product energy data"
   )
   .def_property_readonly(
 

--- a/python/src/TabulatedAverageEnergy.python.cpp
+++ b/python/src/TabulatedAverageEnergy.python.cpp
@@ -1,0 +1,100 @@
+// system includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+#include <pybind11/operators.h>
+
+// local includes
+#include "definitions.hpp"
+#include "dryad/TabulatedAverageEnergy.hpp"
+
+// namespace aliases
+namespace python = pybind11;
+
+void wrapTabulatedAverageEnergy( python::module& module, python::module& ) {
+
+  // type aliases
+  using Component = njoy::dryad::TabulatedAverageEnergy;
+  using InterpolationType = njoy::dryad::InterpolationType;
+  using ToleranceConvergence = njoy::dryad::ToleranceConvergence;
+
+  // wrap views created by this component
+
+  // create the component
+  python::class_< Component > component(
+
+    module,
+    "TabulatedAverageEnergy",
+    "An average reaction product energy table"
+  );
+
+  // wrap the component
+  component
+  .def(
+
+    python::init< std::vector< double >, std::vector< double >,
+                  std::vector< std::size_t >,
+                  std::vector< InterpolationType > >(),
+    python::arg( "energies" ), python::arg( "values" ),
+    python::arg( "boundaries" ), python::arg( "interpolants" ),
+    "Initialise the average reaction product energy table\n\n"
+    "Arguments:\n"
+    "    self           the average reaction product energy table\n"
+    "    energies       the energy values\n"
+    "    values         the average energy values\n"
+    "    boundaries     the boundaries of the interpolation regions\n"
+    "    interpolants   the interpolation types of the interpolation regions,\n"
+    "                   see InterpolationType for all interpolation types"
+  )
+  .def(
+
+    python::init< std::vector< double >, std::vector< double >,
+                  InterpolationType >(),
+    python::arg( "energies" ), python::arg( "values" ),
+    python::arg( "interpolant" ) = InterpolationType::LinearLinear,
+    "Initialise the average reaction product energy table\n\n"
+    "Arguments:\n"
+    "    self           the average reaction product energy table\n"
+    "    energies       the energy values\n"
+    "    values         the average energy values\n"
+    "    interpolant    the interpolation type (default lin-lin),\n"
+    "                   see InterpolationType for all interpolation types"
+  )
+  .def_property_readonly(
+
+    "energies",
+    &Component::energies,
+    "The energy values"
+  )
+  .def_property_readonly(
+
+    "values",
+    &Component::values,
+    "The average energy values"
+  )
+  .def_property_readonly(
+
+    "lower_energy_limit",
+    &Component::lowerEnergyLimit,
+    "The lower energy limit"
+  )
+  .def_property_readonly(
+
+    "upper_energy_limit",
+    &Component::upperEnergyLimit,
+    "The upper energy limit"
+  )
+  .def(
+
+    "__call__",
+    [] ( const Component& self, double energy ) -> decltype(auto)
+       { return self( energy ); },
+    python::arg( "energy" ),
+    "Evaluate the table for a given energy value\n\n"
+    "Arguments:\n"
+    "    self      the table\n"
+    "    energy    the energy value"
+  );
+
+  // add standard tabulated data definitions
+  addStandardTabulatedDefinitions< Component >( component );
+}

--- a/python/src/dryad.python.cpp
+++ b/python/src/dryad.python.cpp
@@ -25,6 +25,7 @@ void wrapTabulatedEnergyDistribution( python::module&, python::module& );
 void wrapTabulatedEnergyDistributions( python::module&, python::module& );
 void wrapTabulatedCrossSection( python::module&, python::module& );
 void wrapTabulatedMultiplicity( python::module&, python::module& );
+void wrapTabulatedAverageEnergy( python::module&, python::module& );
 void wrapReactionProduct( python::module&, python::module& );
 void wrapReaction( python::module&, python::module& );
 void wrapProjectileTarget( python::module&, python::module& );
@@ -61,6 +62,7 @@ PYBIND11_MODULE( dryad, module ) {
 
   // wrap components - reaction products
   wrapTabulatedMultiplicity( module, viewmodule );
+  wrapTabulatedAverageEnergy( module, viewmodule );
   wrapLegendreAngularDistribution( module, viewmodule );
   wrapLegendreAngularDistributions( module, viewmodule );
   wrapTabulatedAngularDistribution( module, viewmodule );

--- a/python/test/Test_dryad_ReactionProduct.py
+++ b/python/test/Test_dryad_ReactionProduct.py
@@ -24,11 +24,15 @@ class Test_dryad_ReactionProduct( unittest.TestCase ) :
             self.assertEqual( True, isinstance( chunk.multiplicity, int ) )
             self.assertEqual( 1, chunk.multiplicity )
 
+            # average reaction product energy
+            self.assertEqual( None, chunk.average_energy )
+
             # distribution data
             self.assertEqual( None, chunk.distribution_data )
 
             # metadata
             self.assertEqual( True, chunk.is_linearised )
+            self.assertEqual( False, chunk.has_average_energy )
             self.assertEqual( False, chunk.has_distribution_data )
 
         def verify_tabulated_chunk( self, chunk ) :
@@ -60,11 +64,15 @@ class Test_dryad_ReactionProduct( unittest.TestCase ) :
             self.assertEqual( InterpolationType.LinearLog, chunk.multiplicity.interpolants[1] )
             self.assertEqual( False, chunk.multiplicity.is_linearised )
 
+            # average reaction product energy
+            self.assertEqual( None, chunk.average_energy )
+
             # distribution data
             self.assertEqual( None, chunk.distribution_data )
 
             # metadata
             self.assertEqual( False, chunk.is_linearised )
+            self.assertEqual( False, chunk.has_average_energy )
             self.assertEqual( False, chunk.has_distribution_data )
 
         def verify_tabulated_linearised_chunk( self, chunk ) :
@@ -110,11 +118,15 @@ class Test_dryad_ReactionProduct( unittest.TestCase ) :
             self.assertEqual( InterpolationType.LinearLinear, chunk.multiplicity.interpolants[1] )
             self.assertEqual( True, chunk.multiplicity.is_linearised )
 
+            # average reaction product energy
+            self.assertEqual( None, chunk.average_energy )
+
             # distribution data
             self.assertEqual( None, chunk.distribution_data )
 
             # metadata
             self.assertEqual( True, chunk.is_linearised )
+            self.assertEqual( False, chunk.has_average_energy )
             self.assertEqual( False, chunk.has_distribution_data )
 
         # the data is given explicitly using an integer multiplicity

--- a/python/test/Test_dryad_TabulatedAverageEnergy.py
+++ b/python/test/Test_dryad_TabulatedAverageEnergy.py
@@ -1,0 +1,1571 @@
+# standard imports
+import unittest
+import sys
+
+# third party imports
+
+# local imports
+from dryad import TabulatedAverageEnergy
+from dryad import InterpolationType
+
+class Test_dryad_TabulatedAverageEnergy( unittest.TestCase ) :
+    """Unit test for the TabulatedAverageEnergy class."""
+
+    def test_component( self ) :
+
+        def verify_chunk1( self, chunk ) :
+
+            # verify content
+            self.assertAlmostEqual( 1., chunk.lower_energy_limit )
+            self.assertAlmostEqual( 4., chunk.upper_energy_limit )
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 2., chunk.values[2] )
+            self.assertAlmostEqual( 1., chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( True, chunk.is_linearised )
+
+            # verify evaluation - values of x in the x grid
+            self.assertAlmostEqual( 4., chunk( energy = 1. ) )
+            self.assertAlmostEqual( 3., chunk( energy = 2. ) )
+            self.assertAlmostEqual( 2., chunk( energy = 3. ) )
+            self.assertAlmostEqual( 1., chunk( energy = 4. ) )
+
+            # verify evaluation - values of x outside the x grid
+            self.assertAlmostEqual( 0.0, chunk( energy = 0. ) )
+            self.assertAlmostEqual( 0.0, chunk( energy = 5. ) )
+
+            # verify evaluation - values of x inside the x grid (lin-lin piece)
+            self.assertAlmostEqual( 3.5, chunk( energy = 1.5 ) )
+            self.assertAlmostEqual( 2.5, chunk( energy = 2.5 ) )
+            self.assertAlmostEqual( 1.5, chunk( energy = 3.5 ) )
+
+            # verify arithmetic operators
+            same = TabulatedAverageEnergy( [ 1., 4. ], [ 0., 3. ] )
+            threshold = TabulatedAverageEnergy( [ 2., 4. ], [ 0., 2. ] )
+            nonzerothreshold = TabulatedAverageEnergy( [ 2., 4. ], [ 1., 3. ] )
+            small = TabulatedAverageEnergy( [ 1., 3. ], [ 0., 2. ] )
+
+            result = -chunk
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual(  1., result.energies[0] )
+            self.assertAlmostEqual(  2., result.energies[1] )
+            self.assertAlmostEqual(  3., result.energies[2] )
+            self.assertAlmostEqual(  4., result.energies[3] )
+            self.assertAlmostEqual( -4., result.values[0] )
+            self.assertAlmostEqual( -3., result.values[1] )
+            self.assertAlmostEqual( -2., result.values[2] )
+            self.assertAlmostEqual( -1., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            chunk += 2.
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )
+            self.assertAlmostEqual( 6., chunk.values[0] )
+            self.assertAlmostEqual( 5., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            chunk -= 2.
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 2., chunk.values[2] )
+            self.assertAlmostEqual( 1., chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            chunk *= 2.
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )
+            self.assertAlmostEqual( 8., chunk.values[0] )
+            self.assertAlmostEqual( 6., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 2., chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            chunk /= 2.
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 2., chunk.values[2] )
+            self.assertAlmostEqual( 1., chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            result = chunk + 2.
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 3., result.energies[2] )
+            self.assertAlmostEqual( 4., result.energies[3] )
+            self.assertAlmostEqual( 6., result.values[0] )
+            self.assertAlmostEqual( 5., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 3., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = 2. + chunk
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 3., result.energies[2] )
+            self.assertAlmostEqual( 4., result.energies[3] )
+            self.assertAlmostEqual( 6., result.values[0] )
+            self.assertAlmostEqual( 5., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 3., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = chunk - 2.
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual(  1., result.energies[0] )
+            self.assertAlmostEqual(  2., result.energies[1] )
+            self.assertAlmostEqual(  3., result.energies[2] )
+            self.assertAlmostEqual(  4., result.energies[3] )
+            self.assertAlmostEqual(  2., result.values[0] )
+            self.assertAlmostEqual(  1., result.values[1] )
+            self.assertAlmostEqual(  0., result.values[2] )
+            self.assertAlmostEqual( -1., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = 2. - chunk
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual(  1., result.energies[0] )
+            self.assertAlmostEqual(  2., result.energies[1] )
+            self.assertAlmostEqual(  3., result.energies[2] )
+            self.assertAlmostEqual(  4., result.energies[3] )
+            self.assertAlmostEqual( -2., result.values[0] )
+            self.assertAlmostEqual( -1., result.values[1] )
+            self.assertAlmostEqual(  0., result.values[2] )
+            self.assertAlmostEqual(  1., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = chunk * 2.
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 3., result.energies[2] )
+            self.assertAlmostEqual( 4., result.energies[3] )
+            self.assertAlmostEqual( 8., result.values[0] )
+            self.assertAlmostEqual( 6., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 2., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = 2. * chunk
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 3., result.energies[2] )
+            self.assertAlmostEqual( 4., result.energies[3] )
+            self.assertAlmostEqual( 8., result.values[0] )
+            self.assertAlmostEqual( 6., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 2., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = chunk / 2.
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 4. , result.energies[3] )
+            self.assertAlmostEqual( 2. , result.values[0] )
+            self.assertAlmostEqual( 1.5, result.values[1] )
+            self.assertAlmostEqual( 1. , result.values[2] )
+            self.assertAlmostEqual( 0.5, result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            chunk += same
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1. , chunk.energies[0] )
+            self.assertAlmostEqual( 2. , chunk.energies[1] )
+            self.assertAlmostEqual( 3. , chunk.energies[2] )
+            self.assertAlmostEqual( 4. , chunk.energies[3] )
+            self.assertAlmostEqual( 4.0, chunk.values[0] )
+            self.assertAlmostEqual( 4.0, chunk.values[1] )
+            self.assertAlmostEqual( 4.0, chunk.values[2] )
+            self.assertAlmostEqual( 4.0, chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            chunk -= same
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1. , chunk.energies[0] )
+            self.assertAlmostEqual( 2. , chunk.energies[1] )
+            self.assertAlmostEqual( 3. , chunk.energies[2] )
+            self.assertAlmostEqual( 4. , chunk.energies[3] )
+            self.assertAlmostEqual( 4.0, chunk.values[0] )
+            self.assertAlmostEqual( 3.0, chunk.values[1] )
+            self.assertAlmostEqual( 2.0, chunk.values[2] )
+            self.assertAlmostEqual( 1.0, chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            result = chunk + same
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 4. , result.energies[3] )
+            self.assertAlmostEqual( 4.0, result.values[0] )
+            self.assertAlmostEqual( 4.0, result.values[1] )
+            self.assertAlmostEqual( 4.0, result.values[2] )
+            self.assertAlmostEqual( 4.0, result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = chunk - same
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 4. , result.energies[3] )
+            self.assertAlmostEqual(  4., result.values[0] )
+            self.assertAlmostEqual(  2., result.values[1] )
+            self.assertAlmostEqual(  0., result.values[2] )
+            self.assertAlmostEqual( -2., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            chunk += threshold
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1. , chunk.energies[0] )
+            self.assertAlmostEqual( 2. , chunk.energies[1] )
+            self.assertAlmostEqual( 3. , chunk.energies[2] )
+            self.assertAlmostEqual( 4. , chunk.energies[3] )
+            self.assertAlmostEqual( 4.0, chunk.values[0] )
+            self.assertAlmostEqual( 3.0, chunk.values[1] )
+            self.assertAlmostEqual( 3.0, chunk.values[2] )
+            self.assertAlmostEqual( 3.0, chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            chunk -= threshold
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1. , chunk.energies[0] )
+            self.assertAlmostEqual( 2. , chunk.energies[1] )
+            self.assertAlmostEqual( 3. , chunk.energies[2] )
+            self.assertAlmostEqual( 4. , chunk.energies[3] )
+            self.assertAlmostEqual( 4.0, chunk.values[0] )
+            self.assertAlmostEqual( 3.0, chunk.values[1] )
+            self.assertAlmostEqual( 2.0, chunk.values[2] )
+            self.assertAlmostEqual( 1.0, chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            result = chunk + threshold
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 4. , result.energies[3] )
+            self.assertAlmostEqual( 4.0, result.values[0] )
+            self.assertAlmostEqual( 3.0, result.values[1] )
+            self.assertAlmostEqual( 3.0, result.values[2] )
+            self.assertAlmostEqual( 3.0, result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            result = chunk - threshold
+            self.assertEqual( 4, result.number_points )
+            self.assertEqual( 1, result.number_regions )
+            self.assertEqual( 4, len( result.energies ) )
+            self.assertEqual( 4, len( result.values ) )
+            self.assertEqual( 1, len( result.boundaries ) )
+            self.assertEqual( 1, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 4. , result.energies[3] )
+            self.assertAlmostEqual(  4., result.values[0] )
+            self.assertAlmostEqual(  3., result.values[1] )
+            self.assertAlmostEqual(  1., result.values[2] )
+            self.assertAlmostEqual( -1., result.values[3] )
+            self.assertEqual( 3, result.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            chunk += nonzerothreshold
+            self.assertEqual( 5, chunk.number_points )
+            self.assertEqual( 2, chunk.number_regions )
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1. , chunk.energies[0] )
+            self.assertAlmostEqual( 2. , chunk.energies[1] )
+            self.assertAlmostEqual( 2. , chunk.energies[2] )
+            self.assertAlmostEqual( 3. , chunk.energies[3] )
+            self.assertAlmostEqual( 4. , chunk.energies[4] )
+            self.assertAlmostEqual( 4.0, chunk.values[0] )
+            self.assertAlmostEqual( 3.0, chunk.values[1] )
+            self.assertAlmostEqual( 4.0, chunk.values[2] )
+            self.assertAlmostEqual( 4.0, chunk.values[3] )
+            self.assertAlmostEqual( 4.0, chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk -= nonzerothreshold
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 1, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 1, len( chunk.boundaries ) )
+            self.assertEqual( 1, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1. , chunk.energies[0] )
+            self.assertAlmostEqual( 2. , chunk.energies[1] )
+            self.assertAlmostEqual( 3. , chunk.energies[2] )
+            self.assertAlmostEqual( 4. , chunk.energies[3] )
+            self.assertAlmostEqual( 4.0, chunk.values[0] )
+            self.assertAlmostEqual( 3.0, chunk.values[1] )
+            self.assertAlmostEqual( 2.0, chunk.values[2] )
+            self.assertAlmostEqual( 1.0, chunk.values[3] )
+            self.assertEqual( 3, chunk.boundaries[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+
+            result = chunk + nonzerothreshold
+            self.assertEqual( 5, result.number_points )
+            self.assertEqual( 2, result.number_regions )
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 2. , result.energies[2] )
+            self.assertAlmostEqual( 3. , result.energies[3] )
+            self.assertAlmostEqual( 4. , result.energies[4] )
+            self.assertAlmostEqual( 4.0, result.values[0] )
+            self.assertAlmostEqual( 3.0, result.values[1] )
+            self.assertAlmostEqual( 4.0, result.values[2] )
+            self.assertAlmostEqual( 4.0, result.values[3] )
+            self.assertAlmostEqual( 4.0, result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk - nonzerothreshold
+            self.assertEqual( 5, result.number_points )
+            self.assertEqual( 2, result.number_regions )
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual(  1. , result.energies[0] )
+            self.assertAlmostEqual(  2. , result.energies[1] )
+            self.assertAlmostEqual(  2. , result.energies[2] )
+            self.assertAlmostEqual(  3. , result.energies[3] )
+            self.assertAlmostEqual(  4. , result.energies[4] )
+            self.assertAlmostEqual(  4., result.values[0] )
+            self.assertAlmostEqual(  3., result.values[1] )
+            self.assertAlmostEqual(  2., result.values[2] )
+            self.assertAlmostEqual(  0., result.values[3] )
+            self.assertAlmostEqual( -2., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            # this will add a second point at the lower end point
+            result = chunk + small
+            self.assertEqual( 5, result.number_points )
+            self.assertEqual( 2, result.number_regions )
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 3. , result.energies[3] )
+            self.assertAlmostEqual( 4. , result.energies[4] )
+            self.assertAlmostEqual( 4.0, result.values[0] )
+            self.assertAlmostEqual( 4.0, result.values[1] )
+            self.assertAlmostEqual( 4.0, result.values[2] )
+            self.assertAlmostEqual( 2.0, result.values[3] )
+            self.assertAlmostEqual( 1.0, result.values[4] )
+            self.assertEqual( 2, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            # this will add a second point at the lower end point
+            result = chunk - small
+            self.assertEqual( 5, result.number_points )
+            self.assertEqual( 2, result.number_regions )
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 3. , result.energies[2] )
+            self.assertAlmostEqual( 3. , result.energies[3] )
+            self.assertAlmostEqual( 4. , result.energies[4] )
+            self.assertAlmostEqual( 4.0, result.values[0] )
+            self.assertAlmostEqual( 2.0, result.values[1] )
+            self.assertAlmostEqual( 0.0, result.values[2] )
+            self.assertAlmostEqual( 2.0, result.values[3] )
+            self.assertAlmostEqual( 1.0, result.values[4] )
+            self.assertEqual( 2, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+
+            # verify linearisation
+            linear = chunk.linearise()
+
+            self.assertEqual( 4, linear.number_points )
+            self.assertEqual( 1, linear.number_regions )
+
+            self.assertEqual( 4, len( linear.energies ) )
+            self.assertEqual( 4, len( linear.values ) )
+            self.assertEqual( 1, len( linear.boundaries ) )
+            self.assertEqual( 1, len( linear.interpolants ) )
+
+            self.assertEqual( 3, linear.boundaries[0] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+
+            self.assertAlmostEqual( 1., linear.energies[0] )
+            self.assertAlmostEqual( 2., linear.energies[1] )
+            self.assertAlmostEqual( 3., linear.energies[2] )
+            self.assertAlmostEqual( 4., linear.energies[3] )
+
+            self.assertAlmostEqual( 4., linear.values[0] )
+            self.assertAlmostEqual( 3., linear.values[1] )
+            self.assertAlmostEqual( 2., linear.values[2] )
+            self.assertAlmostEqual( 1., linear.values[3] )
+
+            self.assertEqual( True, linear.is_linearised )
+
+        def verify_chunk2( self, chunk ) :
+
+            # verify content
+            self.assertAlmostEqual( 1., chunk.lower_energy_limit )
+            self.assertAlmostEqual( 4., chunk.upper_energy_limit )
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+            self.assertEqual( True, chunk.is_linearised )
+
+            # verify evaluation - values of x in the x grid
+            self.assertAlmostEqual( 4., chunk( energy = 1. ) )
+            self.assertAlmostEqual( 4., chunk( energy = 2. ) )
+            self.assertAlmostEqual( 3., chunk( energy = 3. ) )
+            self.assertAlmostEqual( 2., chunk( energy = 4. ) )
+
+            # verify evaluation - values of x outside the x grid
+            self.assertAlmostEqual( 0.0, chunk( energy = 0. ) )
+            self.assertAlmostEqual( 0.0, chunk( energy = 5. ) )
+
+            # verify evaluation - values of x inside the x grid
+            self.assertAlmostEqual( 3.5, chunk( energy = 1.5 ) )
+            self.assertAlmostEqual( 3.5, chunk( energy = 2.5 ) )
+            self.assertAlmostEqual( 2.5, chunk( energy = 3.5 ) )
+
+            # verify arithmetic operators
+            same = TabulatedAverageEnergy( [ 1., 4. ], [ 0., 3. ] )
+            threshold = TabulatedAverageEnergy( [ 2., 4. ], [ 0., 2. ] )
+            nonzerothreshold = TabulatedAverageEnergy( [ 3., 4. ], [ 1., 2. ] )
+            small = TabulatedAverageEnergy( [ 1., 3. ], [ 0., 2. ] )
+
+            result = -chunk
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual(  1., result.energies[0] )
+            self.assertAlmostEqual(  2., result.energies[1] )
+            self.assertAlmostEqual(  2., result.energies[2] )
+            self.assertAlmostEqual(  3., result.energies[3] )
+            self.assertAlmostEqual(  4., result.energies[4] )
+            self.assertAlmostEqual( -4., result.values[0] )
+            self.assertAlmostEqual( -3., result.values[1] )
+            self.assertAlmostEqual( -4., result.values[2] )
+            self.assertAlmostEqual( -3., result.values[3] )
+            self.assertAlmostEqual( -2., result.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk += 2.
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 6., chunk.values[0] )
+            self.assertAlmostEqual( 5., chunk.values[1] )
+            self.assertAlmostEqual( 6., chunk.values[2] )
+            self.assertAlmostEqual( 5., chunk.values[3] )
+            self.assertAlmostEqual( 4., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk -= 2.
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk *= 2.
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 8., chunk.values[0] )
+            self.assertAlmostEqual( 6., chunk.values[1] )
+            self.assertAlmostEqual( 8., chunk.values[2] )
+            self.assertAlmostEqual( 6., chunk.values[3] )
+            self.assertAlmostEqual( 4., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk /= 2.
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            result = chunk + 2.
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 6., result.values[0] )
+            self.assertAlmostEqual( 5., result.values[1] )
+            self.assertAlmostEqual( 6., result.values[2] )
+            self.assertAlmostEqual( 5., result.values[3] )
+            self.assertAlmostEqual( 4., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = 2. + chunk
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 6., result.values[0] )
+            self.assertAlmostEqual( 5., result.values[1] )
+            self.assertAlmostEqual( 6., result.values[2] )
+            self.assertAlmostEqual( 5., result.values[3] )
+            self.assertAlmostEqual( 4., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk - 2.
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 2., result.values[0] )
+            self.assertAlmostEqual( 1., result.values[1] )
+            self.assertAlmostEqual( 2., result.values[2] )
+            self.assertAlmostEqual( 1., result.values[3] )
+            self.assertAlmostEqual( 0., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = 2. - chunk
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual(  1., result.energies[0] )
+            self.assertAlmostEqual(  2., result.energies[1] )
+            self.assertAlmostEqual(  2., result.energies[2] )
+            self.assertAlmostEqual(  3., result.energies[3] )
+            self.assertAlmostEqual(  4., result.energies[4] )
+            self.assertAlmostEqual( -2., result.values[0] )
+            self.assertAlmostEqual( -1., result.values[1] )
+            self.assertAlmostEqual( -2., result.values[2] )
+            self.assertAlmostEqual( -1., result.values[3] )
+            self.assertAlmostEqual(  0., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk * 2.
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 8., result.values[0] )
+            self.assertAlmostEqual( 6., result.values[1] )
+            self.assertAlmostEqual( 8., result.values[2] )
+            self.assertAlmostEqual( 6., result.values[3] )
+            self.assertAlmostEqual( 4., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = 2. * chunk
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 8., result.values[0] )
+            self.assertAlmostEqual( 6., result.values[1] )
+            self.assertAlmostEqual( 8., result.values[2] )
+            self.assertAlmostEqual( 6., result.values[3] )
+            self.assertAlmostEqual( 4., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk / 2.
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1. , result.energies[0] )
+            self.assertAlmostEqual( 2. , result.energies[1] )
+            self.assertAlmostEqual( 2. , result.energies[2] )
+            self.assertAlmostEqual( 3. , result.energies[3] )
+            self.assertAlmostEqual( 4. , result.energies[4] )
+            self.assertAlmostEqual( 2. , result.values[0] )
+            self.assertAlmostEqual( 1.5, result.values[1] )
+            self.assertAlmostEqual( 2. , result.values[2] )
+            self.assertAlmostEqual( 1.5, result.values[3] )
+            self.assertAlmostEqual( 1. , result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            chunk += same
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 4., chunk.values[1] )
+            self.assertAlmostEqual( 5., chunk.values[2] )
+            self.assertAlmostEqual( 5., chunk.values[3] )
+            self.assertAlmostEqual( 5., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk -= same
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            result = chunk + same
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 4., result.values[1] )
+            self.assertAlmostEqual( 5., result.values[2] )
+            self.assertAlmostEqual( 5., result.values[3] )
+            self.assertAlmostEqual( 5., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk - same
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual(  4., result.values[0] )
+            self.assertAlmostEqual(  2., result.values[1] )
+            self.assertAlmostEqual(  3., result.values[2] )
+            self.assertAlmostEqual(  1., result.values[3] )
+            self.assertAlmostEqual( -1., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            chunk += threshold
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 4., chunk.values[3] )
+            self.assertAlmostEqual( 4., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            chunk -= threshold
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            result = chunk + threshold
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 3., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 4., result.values[3] )
+            self.assertAlmostEqual( 4., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            result = chunk - threshold
+            self.assertEqual( 5, len( result.energies ) )
+            self.assertEqual( 5, len( result.values ) )
+            self.assertEqual( 2, len( result.boundaries ) )
+            self.assertEqual( 2, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 4., result.energies[4] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 3., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 2., result.values[3] )
+            self.assertAlmostEqual( 0., result.values[4] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 4, result.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+
+            chunk += nonzerothreshold
+            self.assertEqual( 6, len( chunk.energies ) )
+            self.assertEqual( 6, len( chunk.values ) )
+            self.assertEqual( 3, len( chunk.boundaries ) )
+            self.assertEqual( 3, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 3., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.energies[5] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 4., chunk.values[4] )
+            self.assertAlmostEqual( 4., chunk.values[5] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 3, chunk.boundaries[1] )
+            self.assertEqual( 5, chunk.boundaries[2] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[2] )
+
+            chunk -= nonzerothreshold
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[1] )
+
+            result = chunk + nonzerothreshold
+            self.assertEqual( 6, len( result.energies ) )
+            self.assertEqual( 6, len( result.values ) )
+            self.assertEqual( 3, len( result.boundaries ) )
+            self.assertEqual( 3, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 3., result.energies[4] )
+            self.assertAlmostEqual( 4., result.energies[5] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 3., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 3., result.values[3] )
+            self.assertAlmostEqual( 4., result.values[4] )
+            self.assertAlmostEqual( 4., result.values[5] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 3, result.boundaries[1] )
+            self.assertEqual( 5, result.boundaries[2] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[2] )
+
+            result = chunk - nonzerothreshold
+            self.assertEqual( 6, len( result.energies ) )
+            self.assertEqual( 6, len( result.values ) )
+            self.assertEqual( 3, len( result.boundaries ) )
+            self.assertEqual( 3, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 3., result.energies[4] )
+            self.assertAlmostEqual( 4., result.energies[5] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 3., result.values[1] )
+            self.assertAlmostEqual( 4., result.values[2] )
+            self.assertAlmostEqual( 3., result.values[3] )
+            self.assertAlmostEqual( 2., result.values[4] )
+            self.assertAlmostEqual( 0., result.values[5] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 3, result.boundaries[1] )
+            self.assertEqual( 5, result.boundaries[2] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[2] )
+
+            # this will add a second point at the lower end point
+            result = chunk + small
+            self.assertEqual( 6, len( result.energies ) )
+            self.assertEqual( 6, len( result.values ) )
+            self.assertEqual( 3, len( result.boundaries ) )
+            self.assertEqual( 3, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 3., result.energies[4] )
+            self.assertAlmostEqual( 4., result.energies[5] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 4., result.values[1] )
+            self.assertAlmostEqual( 5., result.values[2] )
+            self.assertAlmostEqual( 5., result.values[3] )
+            self.assertAlmostEqual( 3., result.values[4] )
+            self.assertAlmostEqual( 2., result.values[5] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 3, result.boundaries[1] )
+            self.assertEqual( 5, result.boundaries[2] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[2] )
+
+            # this will add a second point at the lower end point
+            result = chunk - small
+            self.assertEqual( 6, len( result.energies ) )
+            self.assertEqual( 6, len( result.values ) )
+            self.assertEqual( 3, len( result.boundaries ) )
+            self.assertEqual( 3, len( result.interpolants ) )
+            self.assertAlmostEqual( 1., result.energies[0] )
+            self.assertAlmostEqual( 2., result.energies[1] )
+            self.assertAlmostEqual( 2., result.energies[2] )
+            self.assertAlmostEqual( 3., result.energies[3] )
+            self.assertAlmostEqual( 3., result.energies[4] )
+            self.assertAlmostEqual( 4., result.energies[5] )
+            self.assertAlmostEqual( 4., result.values[0] )
+            self.assertAlmostEqual( 2., result.values[1] )
+            self.assertAlmostEqual( 3., result.values[2] )
+            self.assertAlmostEqual( 1., result.values[3] )
+            self.assertAlmostEqual( 3., result.values[4] )
+            self.assertAlmostEqual( 2., result.values[5] )
+            self.assertEqual( 1, result.boundaries[0] )
+            self.assertEqual( 3, result.boundaries[1] )
+            self.assertEqual( 5, result.boundaries[2] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[1] )
+            self.assertEqual( InterpolationType.LinearLinear, result.interpolants[2] )
+
+            # verify linearisation
+            linear = chunk.linearise()
+
+            self.assertEqual( 5, linear.number_points )
+            self.assertEqual( 2, linear.number_regions )
+
+            self.assertEqual( 5, len( linear.energies ) )
+            self.assertEqual( 5, len( linear.values ) )
+            self.assertEqual( 2, len( linear.boundaries ) )
+            self.assertEqual( 2, len( linear.interpolants ) )
+
+            self.assertEqual( 1, linear.boundaries[0] )
+            self.assertEqual( 4, linear.boundaries[1] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[1] )
+
+            self.assertAlmostEqual( 1., linear.energies[0] )
+            self.assertAlmostEqual( 2., linear.energies[1] )
+            self.assertAlmostEqual( 2., linear.energies[2] )
+            self.assertAlmostEqual( 3., linear.energies[3] )
+            self.assertAlmostEqual( 4., linear.energies[4] )
+
+            self.assertAlmostEqual( 4., linear.values[0] )
+            self.assertAlmostEqual( 3., linear.values[1] )
+            self.assertAlmostEqual( 4., linear.values[2] )
+            self.assertAlmostEqual( 3., linear.values[3] )
+            self.assertAlmostEqual( 2., linear.values[4] )
+
+            self.assertEqual( True, linear.is_linearised )
+
+        def verify_chunk3( self, chunk ) :
+
+            # verify content
+            self.assertAlmostEqual( 1., chunk.lower_energy_limit )
+            self.assertAlmostEqual( 4., chunk.upper_energy_limit )
+            self.assertEqual( 4, chunk.number_points )
+            self.assertEqual( 2, chunk.number_regions )
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 2., chunk.values[2] )
+            self.assertAlmostEqual( 1., chunk.values[3] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 3, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLog, chunk.interpolants[1] )
+            self.assertEqual( False, chunk.is_linearised )
+
+            # verify evaluation - values of x in the x grid
+            self.assertAlmostEqual( 4., chunk( energy = 1. ) )
+            self.assertAlmostEqual( 3., chunk( energy = 2. ) )
+            self.assertAlmostEqual( 2., chunk( energy = 3. ) )
+            self.assertAlmostEqual( 1., chunk( energy = 4. ) )
+
+            # verify evaluation - values of x outside the x grid
+            self.assertAlmostEqual( 0.0, chunk( energy = 0. ) )
+            self.assertAlmostEqual( 0.0, chunk( energy = 5. ) )
+
+            # verify evaluation - values of x inside the x grid (lin-lin piece)
+            self.assertAlmostEqual( 3.5, chunk( energy = 1.5 ) )
+
+            # verify evaluation - values of x inside the x grid (lin-lin piece)
+            self.assertAlmostEqual( 2.44966028678679, chunk( energy = 2.5 ) )
+            self.assertAlmostEqual( 1.46416306545103, chunk( energy = 3.5 ) )
+
+            # verify arithmetic operators throw exceptions
+            temp = TabulatedAverageEnergy( [ 1., 4. ], [ 4., 1. ] )
+            with self.assertRaises( Exception ) : result = -chunk
+            with self.assertRaises( Exception ) : result = chunk + 2.
+            with self.assertRaises( Exception ) : result = chunk - 2.
+            with self.assertRaises( Exception ) : result = chunk * 2.
+            with self.assertRaises( Exception ) : result = chunk / 2.
+            with self.assertRaises( Exception ) : result = chunk + temp
+            with self.assertRaises( Exception ) : result = chunk - temp
+            with self.assertRaises( Exception ) : chunk += 2.
+            with self.assertRaises( Exception ) : chunk -= 2.
+            with self.assertRaises( Exception ) : chunk *= 2.
+            with self.assertRaises( Exception ) : chunk /= 2.
+            with self.assertRaises( Exception ) : chunk += temp
+            with self.assertRaises( Exception ) : chunk -= temp
+            with self.assertRaises( Exception ) : result = 2. + chunk
+            with self.assertRaises( Exception ) : result = 2. - chunk
+            with self.assertRaises( Exception ) : result = 2. * chunk
+
+            # verify linearisation
+            linear = chunk.linearise()
+
+            self.assertEqual( 18, linear.number_points )
+            self.assertEqual( 1, linear.number_regions )
+
+            self.assertEqual( 18, len( linear.energies ) )
+            self.assertEqual( 18, len( linear.values ) )
+            self.assertEqual( 1, len( linear.boundaries ) )
+            self.assertEqual( 1, len( linear.interpolants ) )
+
+            self.assertEqual( 17, linear.boundaries[0] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+
+            self.assertAlmostEqual( 1.   , linear.energies[0] )
+            self.assertAlmostEqual( 2.   , linear.energies[1] )
+            self.assertAlmostEqual( 2.125, linear.energies[2] )
+            self.assertAlmostEqual( 2.25 , linear.energies[3] )
+            self.assertAlmostEqual( 2.375, linear.energies[4] )
+            self.assertAlmostEqual( 2.5  , linear.energies[5] )
+            self.assertAlmostEqual( 2.625, linear.energies[6] )
+            self.assertAlmostEqual( 2.75 , linear.energies[7] )
+            self.assertAlmostEqual( 2.875, linear.energies[8] )
+            self.assertAlmostEqual( 3.   , linear.energies[9] )
+            self.assertAlmostEqual( 3.125, linear.energies[10] )
+            self.assertAlmostEqual( 3.25 , linear.energies[11] )
+            self.assertAlmostEqual( 3.375, linear.energies[12] )
+            self.assertAlmostEqual( 3.5  , linear.energies[13] )
+            self.assertAlmostEqual( 3.625, linear.energies[14] )
+            self.assertAlmostEqual( 3.75 , linear.energies[15] )
+            self.assertAlmostEqual( 3.875, linear.energies[16] )
+            self.assertAlmostEqual( 4.   , linear.energies[17] )
+
+            self.assertAlmostEqual( 4.              , linear.values[0] )
+            self.assertAlmostEqual( 3.              , linear.values[1] )
+            self.assertAlmostEqual( 2.85048128530886, linear.values[2] )
+            self.assertAlmostEqual( 2.70951129135145, linear.values[3] )
+            self.assertAlmostEqual( 2.57616511633150, linear.values[4] )
+            self.assertAlmostEqual( 2.44966028678679, linear.values[5] )
+            self.assertAlmostEqual( 2.32932893596581, linear.values[6] )
+            self.assertAlmostEqual( 2.21459646033567, linear.values[7] )
+            self.assertAlmostEqual( 2.10496492439848, linear.values[8] )
+            self.assertAlmostEqual( 2.              , linear.values[9] )
+            self.assertAlmostEqual( 1.85810031827028, linear.values[10] )
+            self.assertAlmostEqual( 1.72176678584324, linear.values[11] )
+            self.assertAlmostEqual( 1.59057916034679, linear.values[12] )
+            self.assertAlmostEqual( 1.46416306545103, linear.values[13] )
+            self.assertAlmostEqual( 1.34218354996644, linear.values[14] )
+            self.assertAlmostEqual( 1.22433973930853, linear.values[15] )
+            self.assertAlmostEqual( 1.11036036428687, linear.values[16] )
+            self.assertAlmostEqual( 1.              , linear.values[17] )
+
+            self.assertEqual( True, linear.is_linearised )
+
+        def verify_chunk4( self, chunk ) :
+
+            # verify content
+            self.assertAlmostEqual( 1., chunk.lower_energy_limit )
+            self.assertAlmostEqual( 4., chunk.upper_energy_limit )
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLog, chunk.interpolants[1] )
+            self.assertEqual( False, chunk.is_linearised )
+
+            # verify evaluation - values of x in the x grid
+            self.assertAlmostEqual( 4., chunk( energy = 1. ) )
+            self.assertAlmostEqual( 4., chunk( energy = 2. ) )
+            self.assertAlmostEqual( 3., chunk( energy = 3. ) )
+            self.assertAlmostEqual( 2., chunk( energy = 4. ) )
+
+            # verify evaluation - values of x outside the x grid
+            self.assertAlmostEqual( 0.0, chunk( energy = 0. ) )
+            self.assertAlmostEqual( 0.0, chunk( energy = 5. ) )
+
+            # verify evaluation - values of x inside the x grid (lin-lin piece)
+            self.assertAlmostEqual( 3.5, chunk( energy = 1.5 ) )
+
+            # verify evaluation - values of x inside the x grid (lin-lin piece)
+            self.assertAlmostEqual( 3.44966028678679, chunk( energy = 2.5 ) )
+            self.assertAlmostEqual( 2.46416306545103, chunk( energy = 3.5 ) )
+
+            # verify arithmetic operators throw exceptions
+            temp = TabulatedAverageEnergy( [ 1., 4. ], [ 4., 1. ] )
+            with self.assertRaises( Exception ) : result = -chunk
+            with self.assertRaises( Exception ) : result = chunk + 2.
+            with self.assertRaises( Exception ) : result = chunk - 2.
+            with self.assertRaises( Exception ) : result = chunk * 2.
+            with self.assertRaises( Exception ) : result = chunk / 2.
+            with self.assertRaises( Exception ) : result = chunk + temp
+            with self.assertRaises( Exception ) : result = chunk - temp
+            with self.assertRaises( Exception ) : chunk += 2.
+            with self.assertRaises( Exception ) : chunk -= 2.
+            with self.assertRaises( Exception ) : chunk *= 2.
+            with self.assertRaises( Exception ) : chunk /= 2.
+            with self.assertRaises( Exception ) : chunk += temp
+            with self.assertRaises( Exception ) : chunk -= temp
+            with self.assertRaises( Exception ) : result = 2. + chunk
+            with self.assertRaises( Exception ) : result = 2. - chunk
+            with self.assertRaises( Exception ) : result = 2. * chunk
+
+            # verify linearisation
+            linear = chunk.linearise()
+
+            self.assertEqual( 12, linear.number_points )
+            self.assertEqual( 2, linear.number_regions )
+
+            self.assertEqual( 12, len( linear.energies ) )
+            self.assertEqual( 12, len( linear.values ) )
+            self.assertEqual( 2, len( linear.boundaries ) )
+            self.assertEqual( 2, len( linear.interpolants ) )
+
+            self.assertEqual(  1, linear.boundaries[0] )
+            self.assertEqual( 11, linear.boundaries[1] )
+
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLinear, linear.interpolants[1] )
+
+            self.assertAlmostEqual( 1.   , linear.energies[0] )
+            self.assertAlmostEqual( 2.   , linear.energies[1] )
+            self.assertAlmostEqual( 2.   , linear.energies[2] )
+            self.assertAlmostEqual( 2.125, linear.energies[3] )
+            self.assertAlmostEqual( 2.25 , linear.energies[4] )
+            self.assertAlmostEqual( 2.5  , linear.energies[5] )
+            self.assertAlmostEqual( 2.75 , linear.energies[6] )
+            self.assertAlmostEqual( 3.   , linear.energies[7] )
+            self.assertAlmostEqual( 3.25 , linear.energies[8] )
+            self.assertAlmostEqual( 3.5  , linear.energies[9] )
+            self.assertAlmostEqual( 3.75 , linear.energies[10] )
+            self.assertAlmostEqual( 4.   , linear.energies[11] )
+
+            self.assertAlmostEqual( 4.              , linear.values[0] )
+            self.assertAlmostEqual( 3.              , linear.values[1] )
+            self.assertAlmostEqual( 4.              , linear.values[2] )
+            self.assertAlmostEqual( 3.85048128530886, linear.values[3] )
+            self.assertAlmostEqual( 3.70951129135145, linear.values[4] )
+            self.assertAlmostEqual( 3.44966028678679, linear.values[5] )
+            self.assertAlmostEqual( 3.21459646033567, linear.values[6] )
+            self.assertAlmostEqual( 3.              , linear.values[7] )
+            self.assertAlmostEqual( 2.72176678584324, linear.values[8] )
+            self.assertAlmostEqual( 2.46416306545103, linear.values[9] )
+            self.assertAlmostEqual( 2.22433973930853, linear.values[10] )
+            self.assertAlmostEqual( 2.              , linear.values[11] )
+
+            self.assertEqual( True, linear.is_linearised )
+
+        def verify_chunk5( self, chunk ) :
+
+            # verify content
+            self.assertEqual( 5, len( chunk.energies ) )
+            self.assertEqual( 5, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 2., chunk.energies[2] )
+            self.assertAlmostEqual( 3., chunk.energies[3] )
+            self.assertAlmostEqual( 4., chunk.energies[4] )
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 4., chunk.values[2] )
+            self.assertAlmostEqual( 3., chunk.values[3] )
+            self.assertAlmostEqual( 2., chunk.values[4] )
+            self.assertEqual( 1, chunk.boundaries[0] )    # <-- this is changed from 2 to 1
+            self.assertEqual( 4, chunk.boundaries[1] )
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLog, chunk.interpolants[1] )
+            self.assertEqual( False, chunk.is_linearised )
+
+        def verify_chunk6( self, chunk ) :
+
+            # verify content
+            self.assertEqual( 4, len( chunk.energies ) )
+            self.assertEqual( 4, len( chunk.values ) )
+            self.assertEqual( 2, len( chunk.boundaries ) )
+            self.assertEqual( 2, len( chunk.interpolants ) )
+            self.assertAlmostEqual( 1., chunk.energies[0] )
+            self.assertAlmostEqual( 2., chunk.energies[1] )
+            self.assertAlmostEqual( 3., chunk.energies[2] )
+            self.assertAlmostEqual( 4., chunk.energies[3] )      # <-- last point removed
+            self.assertAlmostEqual( 4., chunk.values[0] )
+            self.assertAlmostEqual( 3., chunk.values[1] )
+            self.assertAlmostEqual( 2., chunk.values[2] )
+            self.assertAlmostEqual( 1., chunk.values[3] )      # <-- last point removed
+            self.assertEqual( 1, chunk.boundaries[0] )
+            self.assertEqual( 3, chunk.boundaries[1] )    # <-- boundary value reset
+            self.assertEqual( InterpolationType.LinearLinear, chunk.interpolants[0] )
+            self.assertEqual( InterpolationType.LinearLog, chunk.interpolants[1] )
+            self.assertEqual( False, chunk.is_linearised )
+
+        # the data is given explicitly for data without boundaries
+        chunk = TabulatedAverageEnergy( energies = [ 1., 2., 3., 4. ],
+                                        values = [ 4., 3., 2., 1. ],
+                                        interpolant = InterpolationType.LinearLinear )
+
+        verify_chunk1( self, chunk )
+
+        # the data is given explicitly for data without boundaries and a jump
+        chunk = TabulatedAverageEnergy( energies = [ 1., 2., 2., 3., 4. ],
+                                        values = [ 4., 3., 4., 3., 2. ],
+                                        interpolant = InterpolationType.LinearLinear )
+
+        verify_chunk2( self, chunk )
+
+        # the data is given explicitly for data without a jump
+        chunk = TabulatedAverageEnergy( energies = [ 1., 2., 3., 4. ],
+                                        values = [ 4., 3., 2., 1. ],
+                                        boundaries = [ 1, 3 ],
+                                        interpolants = [ InterpolationType.LinearLinear,
+                                                         InterpolationType.LinearLog ] )
+
+        verify_chunk3( self, chunk )
+
+        # the data is given explicitly for data with a jump
+        chunk = TabulatedAverageEnergy( energies = [ 1., 2., 2., 3., 4. ],
+                                        values = [ 4., 3., 4., 3., 2. ],
+                                        boundaries = [ 1, 4 ],
+                                        interpolants = [ InterpolationType.LinearLinear,
+                                                         InterpolationType.LinearLog ] )
+
+        verify_chunk4( self, chunk )
+
+        # the data is given explicitly with boundaries that point to the second x value in the jump
+        chunk = TabulatedAverageEnergy( energies = [ 1., 2., 2., 3., 4. ],
+                                        values = [ 4., 3., 4., 3., 2. ],
+                                        boundaries = [ 2, 4 ],   # <-- pointing to end of the jump
+                                        interpolants = [ InterpolationType.LinearLinear,
+                                                         InterpolationType.LinearLog ] )
+
+        verify_chunk5( self, chunk )
+
+        # the data is given explicitly with a jump at the end that goes to zero
+        chunk = TabulatedAverageEnergy( energies = [ 1., 2., 3., 4., 4. ], # <-- jump at end
+                                        values = [ 4., 3., 2., 1., 0. ], # <-- last value is zero
+                                        boundaries = [ 1, 4 ],      # <-- pointing to end
+                                        interpolants = [ InterpolationType.LinearLinear,
+                                                         InterpolationType.LinearLog ] )
+
+        verify_chunk6( self, chunk )
+
+    def test_failures( self ) :
+
+        print( '\n' )
+
+        # there are not enough values in the x or y grid
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [], values = [] )
+
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1. ], values = [ 4. ] )
+
+        # the x and y grid do not have the same number of points
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 2., 3., 4. ],
+                                            values = [ 4., 3., 2. ] )
+
+        # the boundaries and interpolants do not have the same size
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 2., 3., 4. ],
+                                            values = [ 4., 3., 2., 1. ],
+                                            boundaries = [ 3 ],
+                                            interpolants = [] )
+
+        # the x grid is not sorted
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 3., 2., 4. ],
+                                            values = [ 4., 3., 2., 1. ] )
+
+        # the x grid contains a triple x value
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 2., 2., 2., 3., 4. ],
+                                            values = [ 4., 3., 3., 3., 2., 1. ] )
+
+        # the x grid has a jump at the beginning
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 1., 3., 4. ],
+                                            values = [ 4., 3., 1., 4. ] )
+
+        # the x grid has a jump at the end
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 2., 4., 4. ],
+                                            values = [ 4., 3., 1., 4. ] )
+
+        # the last boundary does not point to the last point
+        with self.assertRaises( Exception ) :
+
+            chunk = TabulatedAverageEnergy( energies = [ 1., 2., 3., 4. ],
+                                            values = [ 4., 3., 2., 1. ],
+                                            boundaries = [ 2 ],
+                                            interpolants = [ InterpolationType.LinearLinear ] )
+
+if __name__ == '__main__' :
+
+    unittest.main()

--- a/src/dryad/ReactionProduct.hpp
+++ b/src/dryad/ReactionProduct.hpp
@@ -10,6 +10,7 @@
 #include "dryad/type-aliases.hpp"
 #include "dryad/id/ParticleID.hpp"
 #include "dryad/TabulatedMultiplicity.hpp"
+#include "dryad/TabulatedAverageEnergy.hpp"
 #include "dryad/TwoBodyDistributionData.hpp"
 #include "dryad/UncorrelatedDistributionData.hpp"
 
@@ -35,6 +36,7 @@ namespace dryad {
     id::ParticleID id_;
 
     Multiplicity multiplicity_;
+    std::optional< TabulatedAverageEnergy > average_energy_;
     std::optional< DistributionData > distribution_;
     bool linearised_;
 
@@ -62,6 +64,14 @@ namespace dryad {
     }
 
     /**
+     *  @brief Return the average reaction product energy
+     */
+    const std::optional< TabulatedAverageEnergy >& averageEnergy() const noexcept {
+
+      return this->average_energy_;
+    }
+
+    /**
      *  @brief Return the reaction product distribution data
      */
     const std::optional< DistributionData >& distributionData() const noexcept {
@@ -75,6 +85,15 @@ namespace dryad {
     bool isLinearised() const noexcept {
 
       return this->linearised_;
+    }
+
+    /**
+     *  @brief Return whether or not the reaction product has average reaction
+     *         product energy data
+     */
+    bool hasAverageEnergy() const noexcept {
+
+      return this->average_energy_.has_value();
     }
 
     /**
@@ -102,10 +121,12 @@ namespace dryad {
 
       id::ParticleID id = this->identifier();
       Multiplicity multiplicity = std::visit( linearise, this->multiplicity() );
+      std::optional< TabulatedAverageEnergy > averageEnergy = this->averageEnergy();
       std::optional< DistributionData > distribution = this->distributionData();
 
       return ReactionProduct( std::move( id ), std::move( multiplicity ),
-                              std::move( distribution ), true );
+                              std::move( averageEnergy ), std::move( distribution ),
+                              true );
     }
 
     /**

--- a/src/dryad/ReactionProduct/src/ctor.hpp
+++ b/src/dryad/ReactionProduct/src/ctor.hpp
@@ -8,10 +8,12 @@
  */
 ReactionProduct( id::ParticleID&& id,
                  Multiplicity&& multiplicity,
+                 std::optional< TabulatedAverageEnergy >&& averageEnergy,
                  std::optional< DistributionData >&& distribution,
                  bool linearised ) :
     id_( std::move( id ) ),
     multiplicity_( std::move( multiplicity ) ),
+    average_energy_( std::move( averageEnergy ) ),
     distribution_( std::move( distribution ) ),
     linearised_( linearised ) {}
 
@@ -34,6 +36,7 @@ ReactionProduct( id::ParticleID id,
     ReactionProduct( std::move( id ),
                      std::move( multiplicity ),
                      std::nullopt,
+                     std::nullopt,
                      std::visit(
                          tools::overload{
                              [] ( int ) { return true; },
@@ -53,7 +56,29 @@ ReactionProduct( id::ParticleID id,
                  DistributionData distribution ) :
     ReactionProduct( std::move( id ),
                      std::move( multiplicity ),
+                     std::nullopt,
                      std::move( distribution ),
+                     std::visit(
+                         tools::overload{
+                             [] ( int ) { return true; },
+                             [] ( const TabulatedMultiplicity& multiplicity )
+                                { return multiplicity.isLinearised(); } },
+                         multiplicity ) ) {}
+
+/**
+ *  @brief Constructor
+ *
+ *  @param id              the reaction product identifier
+ *  @param multiplicity    the reaction product multiplicity
+ *  @param averageEnergy   the average reaction product energy
+ */
+ReactionProduct( id::ParticleID id,
+                 Multiplicity multiplicity,
+                 TabulatedAverageEnergy averageEnergy ) :
+    ReactionProduct( std::move( id ),
+                     std::move( multiplicity ),
+                     std::move( averageEnergy ),
+                     std::nullopt,
                      std::visit(
                          tools::overload{
                              [] ( int ) { return true; },

--- a/src/dryad/ReactionProduct/test/ReactionProduct.test.cpp
+++ b/src/dryad/ReactionProduct/test/ReactionProduct.test.cpp
@@ -95,10 +95,14 @@ void verifyChunk( const ReactionProduct& chunk ) {
   CHECK( 1 == std::get< int >( multiplicity ) );
 
   // distribution data
+  CHECK( std::nullopt == chunk.averageEnergy() );
+
+  // distribution data
   CHECK( std::nullopt == chunk.distributionData() );
 
   // metadata
   CHECK( true == chunk.isLinearised() );
+  CHECK( false == chunk.hasAverageEnergy() );
   CHECK( false == chunk.hasDistributionData() );
 }
 
@@ -133,10 +137,14 @@ void verifyTabulatedChunk( const ReactionProduct& chunk ) {
   CHECK( false == multiplicity.isLinearised() );
 
   // distribution data
+  CHECK( std::nullopt == chunk.averageEnergy() );
+
+  // distribution data
   CHECK( std::nullopt == chunk.distributionData() );
 
   // metadata
   CHECK( false == chunk.isLinearised() );
+  CHECK( false == chunk.hasAverageEnergy() );
   CHECK( false == chunk.hasDistributionData() );
 }
 
@@ -185,9 +193,13 @@ void verifyTabulatedLinearisedChunk( const ReactionProduct& chunk ) {
   CHECK( true == multiplicity.isLinearised() );
 
   // distribution data
+  CHECK( std::nullopt == chunk.averageEnergy() );
+
+  // distribution data
   CHECK( std::nullopt == chunk.distributionData() );
 
   // metadata
   CHECK( true == chunk.isLinearised() );
+  CHECK( false == chunk.hasAverageEnergy() );
   CHECK( false == chunk.hasDistributionData() );
 }

--- a/src/dryad/TabulatedAverageEnergy.hpp
+++ b/src/dryad/TabulatedAverageEnergy.hpp
@@ -1,0 +1,256 @@
+#ifndef NJOY_DRYAD_TABULATEDAVERAGEENERGY
+#define NJOY_DRYAD_TABULATEDAVERAGEENERGY
+
+// system includes
+#include <vector>
+
+// other includes
+#include "dryad/type-aliases.hpp"
+#include "scion/math/InterpolationTable.hpp"
+
+namespace njoy {
+namespace dryad {
+
+  /**
+   *  @class
+   *  @brief An average reaction product energy table
+   */
+  class TabulatedAverageEnergy :
+      protected scion::math::InterpolationTable< double, double > {
+
+  public:
+
+    /* type aliases */
+    using InterpolationTable::XType;
+    using InterpolationTable::YType;
+
+    /* constructor */
+
+    #include "dryad/TabulatedAverageEnergy/src/ctor.hpp"
+
+    /* methods */
+
+    /**
+     *  @brief Return the energy values
+     */
+    const std::vector< double >& energies() const noexcept {
+
+      return this->x();
+    }
+
+    /**
+     *  @brief Return the average energy values
+     */
+    const std::vector< double >& values() const noexcept {
+
+      return this->y();
+    }
+
+    /**
+     *  @brief Return the lower energy limit
+     */
+    double lowerEnergyLimit() const noexcept {
+
+      return this->x().front();
+    }
+
+    /**
+     *  @brief Return the upper energy limit
+     */
+    double upperEnergyLimit() const noexcept {
+
+      return this->x().back();
+    }
+
+    using InterpolationTable::boundaries;
+    using InterpolationTable::interpolants;
+    using InterpolationTable::numberPoints;
+    using InterpolationTable::numberRegions;
+    using InterpolationTable::isLinearised;
+
+    using InterpolationTable::operator();
+
+    /**
+     *  @brief Return a linearised cross section table
+     *
+     *  @param[in] tolerance   the linearisation tolerance
+     */
+    TabulatedAverageEnergy linearise( ToleranceConvergence tolerance = {} ) const {
+
+      return TabulatedAverageEnergy( InterpolationTable::linearise( tolerance ) );
+    }
+
+    /**
+     *  @brief Inplace scalar addition
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy& operator+=( double right ) {
+
+      InterpolationTable::operator+=( right );
+      return *this;
+    }
+
+    /**
+     *  @brief Inplace scalar subtraction
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy& operator-=( double right ) {
+
+      InterpolationTable::operator-=( right );
+      return *this;
+    }
+
+    /**
+     *  @brief Inplace scalar multiplication
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy& operator*=( double right ) {
+
+      InterpolationTable::operator*=( right );
+      return *this;
+    }
+
+    /**
+     *  @brief Inplace scalar division
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy& operator/=( double right ) {
+
+      InterpolationTable::operator/=( right );
+      return *this;
+    }
+
+    /**
+     *  @brief TabulatedAverageEnergy and scalar addition
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy operator+( double right ) const {
+
+      return InterpolationTable::operator+( right );
+    }
+
+    /**
+     *  @brief TabulatedAverageEnergy and scalar subtraction
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy operator-( double right ) const {
+
+      return InterpolationTable::operator-( right );
+    }
+
+    /**
+     *  @brief TabulatedAverageEnergy and scalar multiplication
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy operator*( double right ) const {
+
+      return InterpolationTable::operator*( right );
+    }
+
+    /**
+     *  @brief TabulatedAverageEnergy and scalar division
+     *
+     *  @param[in] right    the scalar
+     */
+    TabulatedAverageEnergy operator/( double right ) const {
+
+      return InterpolationTable::operator/( right );
+    }
+
+    /**
+     *  @brief Unary minus
+     */
+    TabulatedAverageEnergy operator-() const {
+
+      return InterpolationTable::operator-();
+    }
+
+    /**
+     *  @brief Inplace TabulatedAverageEnergy addition
+     *
+     *  @param[in] right    the table
+     */
+    TabulatedAverageEnergy& operator+=( const TabulatedAverageEnergy& right ) {
+
+      InterpolationTable::operator+=( right );
+      return *this;
+    }
+
+    /**
+     *  @brief Inplace TabulatedAverageEnergy subtraction
+     *
+     *  @param[in] right    the table
+     */
+    TabulatedAverageEnergy& operator-=( const TabulatedAverageEnergy& right ) {
+
+      InterpolationTable::operator-=( right );
+      return *this;
+    }
+
+    /**
+     *  @brief TabulatedAverageEnergy and TabulatedAverageEnergy addition
+     *
+     *  @param[in] right    the table
+     */
+    TabulatedAverageEnergy operator+( const TabulatedAverageEnergy& right ) const {
+
+      return InterpolationTable::operator+( right );
+    }
+
+    /**
+     *  @brief TabulatedAverageEnergy and TabulatedAverageEnergy subtraction
+     *
+     *  @param[in] right    the table
+     */
+    TabulatedAverageEnergy operator-( const TabulatedAverageEnergy& right ) const {
+
+      return InterpolationTable::operator-( right );
+    }
+  };
+
+  /**
+   *  @brief Scalar and TabulatedAverageEnergy addition
+   *
+   *  @param[in] left    the scalar
+   *  @param[in] right   the table
+   */
+  inline TabulatedAverageEnergy operator+( double left, const TabulatedAverageEnergy& right ) {
+
+    return right + left;
+  }
+
+  /**
+   *  @brief Scalar and TabulatedAverageEnergy subtraction
+   *
+   *  @param[in] left    the scalar
+   *  @param[in] right   the table
+   */
+  inline TabulatedAverageEnergy operator-( double left, const TabulatedAverageEnergy& right ) {
+
+    auto result = -right;
+    result += left;
+    return result;
+  }
+
+  /**
+   *  @brief Scalar and TabulatedAverageEnergy multiplication
+   *
+   *  @param[in] left    the scalar
+   *  @param[in] right   the table
+   */
+  inline TabulatedAverageEnergy operator*( double left, const TabulatedAverageEnergy& right ) {
+
+    return right * left;
+  }
+
+} // dryad namespace
+} // njoy namespace
+
+#endif

--- a/src/dryad/TabulatedAverageEnergy/src/ctor.hpp
+++ b/src/dryad/TabulatedAverageEnergy/src/ctor.hpp
@@ -1,0 +1,44 @@
+private:
+
+/**
+ *  @brief Private constructor
+ *
+ *  @param table   the interpolation table
+ */
+TabulatedAverageEnergy( InterpolationTable< double, double > table ) :
+  InterpolationTable( std::move( table ) ) {}
+
+public:
+
+TabulatedAverageEnergy( const TabulatedAverageEnergy& ) = default;
+TabulatedAverageEnergy( TabulatedAverageEnergy&& ) = default;
+
+TabulatedAverageEnergy& operator=( const TabulatedAverageEnergy& ) = default;
+TabulatedAverageEnergy& operator=( TabulatedAverageEnergy&& ) = default;
+
+/**
+ *  @brief Constructor
+ *
+ *  @param energies       the energy values
+ *  @param values         the average energy values
+ *  @param boundaries     the boundaries of the interpolation regions
+ *  @param interpolants   the interpolation types of the interpolation regions
+ */
+TabulatedAverageEnergy( std::vector< double > energies,
+                        std::vector< double > values,
+                        std::vector< std::size_t > boundaries,
+                        std::vector< InterpolationType > interpolants ) :
+  InterpolationTable( std::move( energies ), std::move( values ),
+                      std::move( boundaries ), std::move( interpolants ) ) {}
+
+/**
+ *  @brief Constructor for a cross section using a single interpolation zone
+ *
+ *  @param energies       the energy values
+ *  @param values         the cross section values
+ *  @param interpolant    the interpolation type of the data (default lin-lin)
+ */
+TabulatedAverageEnergy( std::vector< double > energies,
+                        std::vector< double > values,
+                        InterpolationType interpolant = InterpolationType::LinearLinear ) :
+  InterpolationTable( std::move( energies ), std::move( values ), interpolant ) {}

--- a/src/dryad/TabulatedAverageEnergy/test/CMakeLists.txt
+++ b/src/dryad/TabulatedAverageEnergy/test/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_cpp_test( TabulatedAverageEnergy TabulatedAverageEnergy.test.cpp )

--- a/src/dryad/TabulatedAverageEnergy/test/TabulatedAverageEnergy.test.cpp
+++ b/src/dryad/TabulatedAverageEnergy/test/TabulatedAverageEnergy.test.cpp
@@ -1,0 +1,1765 @@
+// include Catch2
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+using Catch::Matchers::WithinRel;
+
+// what we are testing
+#include "dryad/TabulatedAverageEnergy.hpp"
+
+// other includes
+
+// convenience typedefs
+using namespace njoy::dryad;
+
+SCENARIO( "TabulatedAverageEnergy" ) {
+
+  GIVEN( "linearised data without boundaries and no jumps" ) {
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > energies = { 1., 2., 3., 4. };
+      const std::vector< double > values = { 4., 3., 2., 1. };
+
+      TabulatedAverageEnergy chunk( std::move( energies ), std::move( values ) );
+
+      THEN( "a TabulatedAverageEnergy can be constructed and members can be tested" ) {
+
+        CHECK_THAT( 1., WithinRel( chunk.lowerEnergyLimit() ) );
+        CHECK_THAT( 4., WithinRel( chunk.upperEnergyLimit() ) );
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( true == chunk.isLinearised() );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be evaluated" ) {
+
+        // values of x in the x grid
+        CHECK_THAT( 4., WithinRel( chunk( 1. ) ) );
+        CHECK_THAT( 3., WithinRel( chunk( 2. ) ) );
+        CHECK_THAT( 2., WithinRel( chunk( 3. ) ) );
+        CHECK_THAT( 1., WithinRel( chunk( 4. ) ) );
+
+        // values of x outside the x grid
+        CHECK_THAT( 0., WithinRel( chunk( 0. ) ) );
+        CHECK_THAT( 0., WithinRel( chunk( 5. ) ) );
+
+        // values of x inside the x grid
+        CHECK_THAT( 3.5, WithinRel( chunk( 1.5 ) ) );
+        CHECK_THAT( 2.5, WithinRel( chunk( 2.5 ) ) );
+        CHECK_THAT( 1.5, WithinRel( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "arithmetic operations can be performed" ) {
+
+        TabulatedAverageEnergy result( { 1., 4. }, { 0., 0. } );
+        TabulatedAverageEnergy same( { 1., 4. }, { 0., 3. } );
+        TabulatedAverageEnergy threshold( { 2., 4. }, { 0., 2. } );
+        TabulatedAverageEnergy nonzerothreshold( { 2., 4. }, { 1., 3. } );
+        TabulatedAverageEnergy small( { 1., 3. }, { 0., 2. } );
+
+        chunk += 2.;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 6., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 5., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        chunk -= 2.;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        chunk *= 2.;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 8., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 6., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        chunk /= 2.;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        result = -chunk;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT(  1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT(  3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT(  4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( -4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( -3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[2] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = chunk + 2.;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = 2. + chunk;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = chunk - 2.;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT(  1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT(  3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT(  4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT(  2., WithinRel( result.values()[0] ) );
+        CHECK_THAT(  1., WithinRel( result.values()[1] ) );
+        CHECK_THAT(  0., WithinRel( result.values()[2] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = 2. - chunk;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT(  1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT(  3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT(  4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[0] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[1] ) );
+        CHECK_THAT(  0., WithinRel( result.values()[2] ) );
+        CHECK_THAT(  1., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = chunk * 2.;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 8., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = 2. * chunk;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 8., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = chunk / 2.;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 2.0, WithinRel( result.values()[0] ) );
+        CHECK_THAT( 1.5, WithinRel( result.values()[1] ) );
+        CHECK_THAT( 1.0, WithinRel( result.values()[2] ) );
+        CHECK_THAT( 0.5, WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        chunk += same;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        chunk -= same;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3.0, WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2.0, WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1.0, WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        result = chunk + same;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[0] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[2] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = chunk - same;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT(  4., WithinRel( result.values()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.values()[1] ) );
+        CHECK_THAT(  0., WithinRel( result.values()[2] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        chunk += threshold;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3.0, WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 3.0, WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3.0, WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        chunk -= threshold;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3.0, WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2.0, WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1.0, WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        result = chunk + threshold;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[0] ) );
+        CHECK_THAT( 3.0, WithinRel( result.values()[1] ) );
+        CHECK_THAT( 3.0, WithinRel( result.values()[2] ) );
+        CHECK_THAT( 3.0, WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        result = chunk - threshold;
+
+        CHECK( 4 == result.numberPoints() );
+        CHECK( 1 == result.numberRegions() );
+        CHECK( 4 == result.energies().size() );
+        CHECK( 4 == result.values().size() );
+        CHECK( 1 == result.boundaries().size() );
+        CHECK( 1 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT(  4., WithinRel( result.values()[0] ) );
+        CHECK_THAT(  3., WithinRel( result.values()[1] ) );
+        CHECK_THAT(  1., WithinRel( result.values()[2] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[3] ) );
+        CHECK( 3 == result.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        chunk += nonzerothreshold;
+
+        CHECK( 5 == chunk.numberPoints() );
+        CHECK( 2 == chunk.numberRegions() );
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        chunk -= nonzerothreshold;
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 1 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 1 == chunk.boundaries().size() );
+        CHECK( 1 == chunk.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4. , WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4.0, WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3.0, WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2.0, WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1.0, WithinRel( chunk.values()[3] ) );
+        CHECK( 3 == chunk.boundaries()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+
+        result = chunk + nonzerothreshold;
+
+        CHECK( 5 == result.numberPoints() );
+        CHECK( 2 == result.numberRegions() );
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk - nonzerothreshold;
+
+        CHECK( 5 == result.numberPoints() );
+        CHECK( 2 == result.numberRegions() );
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT(  1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT(  3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT(  4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT(  4., WithinRel( result.values()[0] ) );
+        CHECK_THAT(  3., WithinRel( result.values()[1] ) );
+        CHECK_THAT(  2., WithinRel( result.values()[2] ) );
+        CHECK_THAT(  0., WithinRel( result.values()[3] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        // this will add a second point at the lower end point
+        result = chunk + small;
+
+        CHECK( 5 == result.numberPoints() );
+        CHECK( 2 == result.numberRegions() );
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[0] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[2] ) );
+        CHECK_THAT( 2.0, WithinRel( result.values()[3] ) );
+        CHECK_THAT( 1.0, WithinRel( result.values()[4] ) );
+        CHECK( 2 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+
+        // this will add a second point at the lower end point
+        result = chunk - small;
+
+        CHECK( 5 == result.numberPoints() );
+        CHECK( 2 == result.numberRegions() );
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4.0, WithinRel( result.values()[0] ) );
+        CHECK_THAT( 2.0, WithinRel( result.values()[1] ) );
+        CHECK_THAT( 0.0, WithinRel( result.values()[2] ) );
+        CHECK_THAT( 2.0, WithinRel( result.values()[3] ) );
+        CHECK_THAT( 1.0, WithinRel( result.values()[4] ) );
+        CHECK( 2 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be linearised" ) {
+
+        TabulatedAverageEnergy linear = chunk.linearise();
+
+        CHECK( 4 == linear.numberPoints() );
+        CHECK( 1 == linear.numberRegions() );
+
+        CHECK( 4 == linear.energies().size() );
+        CHECK( 4 == linear.values().size() );
+        CHECK( 1 == linear.boundaries().size() );
+        CHECK( 1 == linear.interpolants().size() );
+
+        CHECK( 3 == linear.boundaries()[0] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+
+        CHECK_THAT( 1., WithinRel( linear.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( linear.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( linear.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( linear.energies()[3] ) );
+
+        CHECK_THAT( 4., WithinRel( linear.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( linear.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( linear.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( linear.values()[3] ) );
+
+        CHECK( true == linear.isLinearised() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "linearised data without boundaries and a jump" ) {
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > energies = { 1., 2., 2., 3., 4. };
+      const std::vector< double > values = { 4., 3., 4., 3., 2. };
+      InterpolationType interpolant = InterpolationType::LinearLinear;
+
+      TabulatedAverageEnergy chunk( std::move( energies ), std::move( values ),
+                                   interpolant );
+
+      THEN( "a TabulatedAverageEnergy can be constructed and members can be tested" ) {
+
+        // the constructor will detect the jump and add interpolation regions
+        // as required
+        CHECK_THAT( 1., WithinRel( chunk.lowerEnergyLimit() ) );
+        CHECK_THAT( 4., WithinRel( chunk.upperEnergyLimit() ) );
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+        CHECK( true == chunk.isLinearised() );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be evaluated" ) {
+
+        // values of x in the x grid
+        CHECK_THAT( 4., WithinRel( chunk( 1. ) ) );
+        CHECK_THAT( 4., WithinRel( chunk( 2. ) ) );
+        CHECK_THAT( 3., WithinRel( chunk( 3. ) ) );
+        CHECK_THAT( 2., WithinRel( chunk( 4. ) ) );
+
+        // values of x outside the x grid
+        CHECK_THAT( 0., WithinRel( chunk( 0. ) ) );
+        CHECK_THAT( 0., WithinRel( chunk( 5. ) ) );
+
+        // values of x inside the x grid
+        CHECK_THAT( 3.5, WithinRel( chunk( 1.5 ) ) );
+        CHECK_THAT( 3.5, WithinRel( chunk( 2.5 ) ) );
+        CHECK_THAT( 2.5, WithinRel( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "arithmetic operations can be performed" ) {
+
+        TabulatedAverageEnergy result( { 1., 4. }, { 0., 0. } );
+        TabulatedAverageEnergy same( { 1., 4. }, { 0., 3. } );
+        TabulatedAverageEnergy threshold( { 2., 4. }, { 0., 2. } );
+        TabulatedAverageEnergy nonzerothreshold( { 3., 4. }, { 1., 2. } );
+        TabulatedAverageEnergy small( { 1., 3. }, { 0., 2. } );
+
+        chunk += 2.;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 6., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 5., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 6., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 5., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        chunk -= 2.;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        chunk *= 2.;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 8., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 6., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 8., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 6., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        chunk /= 2.;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        result = -chunk;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT(  1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT(  3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT(  4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( -4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( -3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( -4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( -3., WithinRel( result.values()[3] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk + 2.;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = 2. + chunk;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk - 2.;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 1., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 0., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = 2. - chunk;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT(  1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT(  2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT(  3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT(  4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[0] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[1] ) );
+        CHECK_THAT( -2., WithinRel( result.values()[2] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[3] ) );
+        CHECK_THAT(  0., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk * 2.;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 8., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 8., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = 2. * chunk;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 8., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 8., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 6., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk / 2.;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1. , WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2. , WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3. , WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4. , WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 2. , WithinRel( result.values()[0] ) );
+        CHECK_THAT( 1.5, WithinRel( result.values()[1] ) );
+        CHECK_THAT( 2. , WithinRel( result.values()[2] ) );
+        CHECK_THAT( 1.5, WithinRel( result.values()[3] ) );
+        CHECK_THAT( 1. , WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        chunk += same;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 5., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 5., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 5., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        chunk -= same;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        result = chunk + same;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk - same;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT(  4., WithinRel( result.values()[0] ) );
+        CHECK_THAT(  2., WithinRel( result.values()[1] ) );
+        CHECK_THAT(  3., WithinRel( result.values()[2] ) );
+        CHECK_THAT(  1., WithinRel( result.values()[3] ) );
+        CHECK_THAT( -1., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        chunk += threshold;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        chunk -= threshold;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        result = chunk + threshold;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        result = chunk - threshold;
+
+        CHECK( 5 == result.energies().size() );
+        CHECK( 5 == result.values().size() );
+        CHECK( 2 == result.boundaries().size() );
+        CHECK( 2 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 0., WithinRel( result.values()[4] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 4 == result.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+
+        chunk += nonzerothreshold;
+
+        CHECK( 6 == chunk.energies().size() );
+        CHECK( 6 == chunk.values().size() );
+        CHECK( 3 == chunk.boundaries().size() );
+        CHECK( 3 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[5] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[5] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 3 == chunk.boundaries()[1] );
+        CHECK( 5 == chunk.boundaries()[2] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[2] );
+
+        chunk -= nonzerothreshold;
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[1] );
+
+        result = chunk + nonzerothreshold;
+
+        CHECK( 6 == result.energies().size() );
+        CHECK( 6 == result.values().size() );
+        CHECK( 3 == result.boundaries().size() );
+        CHECK( 3 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[5] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[5] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 3 == result.boundaries()[1] );
+        CHECK( 5 == result.boundaries()[2] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[2] );
+
+        result = chunk - nonzerothreshold;
+
+        CHECK( 6 == result.energies().size() );
+        CHECK( 6 == result.values().size() );
+        CHECK( 3 == result.boundaries().size() );
+        CHECK( 3 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[5] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[4] ) );
+        CHECK_THAT( 0., WithinRel( result.values()[5] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 3 == result.boundaries()[1] );
+        CHECK( 5 == result.boundaries()[2] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[2] );
+
+        // this will add a second point at the lower end point
+        result = chunk + small;
+
+        CHECK( 6 == result.energies().size() );
+        CHECK( 6 == result.values().size() );
+        CHECK( 3 == result.boundaries().size() );
+        CHECK( 3 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[5] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 5., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[4] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[5] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 3 == result.boundaries()[1] );
+        CHECK( 5 == result.boundaries()[2] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[2] );
+
+        // this will add a second point at the lower end point
+        result = chunk - small;
+
+        CHECK( 6 == result.energies().size() );
+        CHECK( 6 == result.values().size() );
+        CHECK( 3 == result.boundaries().size() );
+        CHECK( 3 == result.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( result.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( result.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[3] ) );
+        CHECK_THAT( 3., WithinRel( result.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( result.energies()[5] ) );
+        CHECK_THAT( 4., WithinRel( result.values()[0] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[1] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( result.values()[3] ) );
+        CHECK_THAT( 3., WithinRel( result.values()[4] ) );
+        CHECK_THAT( 2., WithinRel( result.values()[5] ) );
+        CHECK( 1 == result.boundaries()[0] );
+        CHECK( 3 == result.boundaries()[1] );
+        CHECK( 5 == result.boundaries()[2] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[1] );
+        CHECK( InterpolationType::LinearLinear == result.interpolants()[2] );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be linearised" ) {
+
+        TabulatedAverageEnergy linear = chunk.linearise();
+
+        CHECK( 5 == linear.numberPoints() );
+        CHECK( 2 == linear.numberRegions() );
+
+        CHECK( 5 == linear.energies().size() );
+        CHECK( 5 == linear.values().size() );
+        CHECK( 2 == linear.boundaries().size() );
+        CHECK( 2 == linear.interpolants().size() );
+
+        CHECK( 1 == linear.boundaries()[0] );
+        CHECK( 4 == linear.boundaries()[1] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[1] );
+
+        CHECK_THAT( 1., WithinRel( linear.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( linear.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( linear.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( linear.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( linear.energies()[4] ) );
+
+        CHECK_THAT( 4., WithinRel( linear.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( linear.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( linear.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( linear.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( linear.values()[4] ) );
+
+        CHECK( true == linear.isLinearised() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "non-linearised data with multiple regions without a jump" ) {
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > energies = { 1., 2., 3., 4. };
+      const std::vector< double > values = { 4., 3., 2., 1. };
+      const std::vector< std::size_t > boundaries = { 1, 3 };
+      const std::vector< InterpolationType > interpolants = {
+
+        InterpolationType::LinearLinear,
+        InterpolationType::LinearLog
+      };
+
+      TabulatedAverageEnergy chunk( std::move( energies ),
+                                   std::move( values ),
+                                   std::move( boundaries ),
+                                   std::move( interpolants ) );
+
+      THEN( "a TabulatedAverageEnergy can be constructed and members can be tested" ) {
+
+        CHECK_THAT( 1., WithinRel( chunk.lowerEnergyLimit() ) );
+        CHECK_THAT( 4., WithinRel( chunk.upperEnergyLimit() ) );
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 2 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( chunk.values()[3] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 3 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLog == chunk.interpolants()[1] );
+        CHECK( false == chunk.isLinearised() );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be evaluated" ) {
+
+        // values of x in the x grid
+        CHECK_THAT( 4., WithinRel( chunk( 1. ) ) );
+        CHECK_THAT( 3., WithinRel( chunk( 2. ) ) );
+        CHECK_THAT( 2., WithinRel( chunk( 3. ) ) );
+        CHECK_THAT( 1., WithinRel( chunk( 4. ) ) );
+
+        // values of x outside the x grid
+        CHECK_THAT( 0., WithinRel( chunk( 0. ) ) );
+        CHECK_THAT( 0., WithinRel( chunk( 5. ) ) );
+
+        // values of x inside the x grid (lin-lin piece)
+        CHECK_THAT( 3.5, WithinRel( chunk( 1.5 ) ) );
+
+        // values of x inside the x grid (lin-log piece)
+        CHECK_THAT( 2.44966028678679, WithinRel( chunk( 2.5 ) ) );
+        CHECK_THAT( 1.46416306545103, WithinRel( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "arithmetic operations cannot be performed" ) {
+
+        TabulatedAverageEnergy result( { 1., 4. }, { 0., 0. } );
+        TabulatedAverageEnergy right( { 1., 4. }, { 0., 0. } );
+
+        // scalar operations
+        CHECK_THROWS( chunk += 2. );
+        CHECK_THROWS( chunk -= 2. );
+        CHECK_THROWS( chunk *= 2. );
+        CHECK_THROWS( chunk /= 2. );
+        CHECK_THROWS( result = -chunk );
+        CHECK_THROWS( result = chunk + 2. );
+        CHECK_THROWS( result = chunk - 2. );
+        CHECK_THROWS( result = chunk * 2. );
+        CHECK_THROWS( result = chunk / 2. );
+        CHECK_THROWS( result = 2. + chunk );
+        CHECK_THROWS( result = 2. - chunk );
+        CHECK_THROWS( result = 2. * chunk );
+
+        // table operations
+        CHECK_THROWS( chunk += right );
+        CHECK_THROWS( chunk -= right );
+        CHECK_THROWS( result = chunk + right );
+        CHECK_THROWS( result = chunk - right );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be linearised" ) {
+
+        TabulatedAverageEnergy linear = chunk.linearise();
+
+        CHECK( 18 == linear.numberPoints() );
+        CHECK( 1 == linear.numberRegions() );
+
+        CHECK( 18 == linear.energies().size() );
+        CHECK( 18 == linear.values().size() );
+        CHECK( 1 == linear.boundaries().size() );
+        CHECK( 1 == linear.interpolants().size() );
+
+        CHECK( 17 == linear.boundaries()[0] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+
+        CHECK_THAT( 1.   , WithinRel( linear.energies()[0] ) );
+        CHECK_THAT( 2.   , WithinRel( linear.energies()[1] ) );
+        CHECK_THAT( 2.125, WithinRel( linear.energies()[2] ) );
+        CHECK_THAT( 2.25 , WithinRel( linear.energies()[3] ) );
+        CHECK_THAT( 2.375, WithinRel( linear.energies()[4] ) );
+        CHECK_THAT( 2.5  , WithinRel( linear.energies()[5] ) );
+        CHECK_THAT( 2.625, WithinRel( linear.energies()[6] ) );
+        CHECK_THAT( 2.75 , WithinRel( linear.energies()[7] ) );
+        CHECK_THAT( 2.875, WithinRel( linear.energies()[8] ) );
+        CHECK_THAT( 3.   , WithinRel( linear.energies()[9] ) );
+        CHECK_THAT( 3.125, WithinRel( linear.energies()[10] ) );
+        CHECK_THAT( 3.25 , WithinRel( linear.energies()[11] ) );
+        CHECK_THAT( 3.375, WithinRel( linear.energies()[12] ) );
+        CHECK_THAT( 3.5  , WithinRel( linear.energies()[13] ) );
+        CHECK_THAT( 3.625, WithinRel( linear.energies()[14] ) );
+        CHECK_THAT( 3.75 , WithinRel( linear.energies()[15] ) );
+        CHECK_THAT( 3.875, WithinRel( linear.energies()[16] ) );
+        CHECK_THAT( 4.   , WithinRel( linear.energies()[17] ) );
+
+        CHECK_THAT( 4.              , WithinRel( linear.values()[0] ) );
+        CHECK_THAT( 3.              , WithinRel( linear.values()[1] ) );
+        CHECK_THAT( 2.85048128530886, WithinRel( linear.values()[2] ) );
+        CHECK_THAT( 2.70951129135145, WithinRel( linear.values()[3] ) );
+        CHECK_THAT( 2.57616511633150, WithinRel( linear.values()[4] ) );
+        CHECK_THAT( 2.44966028678679, WithinRel( linear.values()[5] ) );
+        CHECK_THAT( 2.32932893596581, WithinRel( linear.values()[6] ) );
+        CHECK_THAT( 2.21459646033567, WithinRel( linear.values()[7] ) );
+        CHECK_THAT( 2.10496492439848, WithinRel( linear.values()[8] ) );
+        CHECK_THAT( 2.              , WithinRel( linear.values()[9] ) );
+        CHECK_THAT( 1.85810031827028, WithinRel( linear.values()[10] ) );
+        CHECK_THAT( 1.72176678584324, WithinRel( linear.values()[11] ) );
+        CHECK_THAT( 1.59057916034679, WithinRel( linear.values()[12] ) );
+        CHECK_THAT( 1.46416306545103, WithinRel( linear.values()[13] ) );
+        CHECK_THAT( 1.34218354996644, WithinRel( linear.values()[14] ) );
+        CHECK_THAT( 1.22433973930853, WithinRel( linear.values()[15] ) );
+        CHECK_THAT( 1.11036036428687, WithinRel( linear.values()[16] ) );
+        CHECK_THAT( 1.              , WithinRel( linear.values()[17] ) );
+
+        CHECK( true == linear.isLinearised() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "non-linearised data with multiple regions with a jump" ) {
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > energies = { 1., 2., 2., 3., 4. };
+      const std::vector< double > values = { 4., 3., 4., 3., 2. };
+      const std::vector< std::size_t > boundaries = { 1, 4 };
+      const std::vector< InterpolationType > interpolants = {
+
+        InterpolationType::LinearLinear,
+        InterpolationType::LinearLog
+      };
+
+      TabulatedAverageEnergy chunk( std::move( energies ),
+                                   std::move( values ),
+                                   std::move( boundaries ),
+                                   std::move( interpolants ) );
+
+      THEN( "a TabulatedAverageEnergy can be constructed and members can be tested" ) {
+
+        CHECK_THAT( 1., WithinRel( chunk.lowerEnergyLimit() ) );
+        CHECK_THAT( 4., WithinRel( chunk.upperEnergyLimit() ) );
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLog == chunk.interpolants()[1] );
+        CHECK( false == chunk.isLinearised() );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be evaluated" ) {
+
+        // values of x in the x grid
+        CHECK_THAT( 4., WithinRel( chunk( 1. ) ) );
+        CHECK_THAT( 4., WithinRel( chunk( 2. ) ) );
+        CHECK_THAT( 3., WithinRel( chunk( 3. ) ) );
+        CHECK_THAT( 2., WithinRel( chunk( 4. ) ) );
+
+        // values of x outside the x grid
+        CHECK_THAT( 0., WithinRel( chunk( 0. ) ) );
+        CHECK_THAT( 0., WithinRel( chunk( 5. ) ) );
+
+        // values of x inside the x grid (lin-lin piece)
+        CHECK_THAT( 3.5, WithinRel( chunk( 1.5 ) ) );
+
+        // values of x inside the x grid (lin-log piece)
+        CHECK_THAT( 3.44966028678679, WithinRel( chunk( 2.5 ) ) );
+        CHECK_THAT( 2.46416306545103, WithinRel( chunk( 3.5 ) ) );
+      } // THEN
+
+      THEN( "arithmetic operations cannot be performed" ) {
+
+        TabulatedAverageEnergy result( { 1., 4. }, { 0., 0. } );
+        TabulatedAverageEnergy right( { 1., 4. }, { 0., 0. } );
+
+        // scalar operations
+        CHECK_THROWS( chunk += 2. );
+        CHECK_THROWS( chunk -= 2. );
+        CHECK_THROWS( chunk *= 2. );
+        CHECK_THROWS( chunk /= 2. );
+        CHECK_THROWS( result = -chunk );
+        CHECK_THROWS( result = chunk + 2. );
+        CHECK_THROWS( result = chunk - 2. );
+        CHECK_THROWS( result = chunk * 2. );
+        CHECK_THROWS( result = chunk / 2. );
+        CHECK_THROWS( result = 2. + chunk );
+        CHECK_THROWS( result = 2. - chunk );
+        CHECK_THROWS( result = 2. * chunk );
+
+        // table operations
+        CHECK_THROWS( chunk += right );
+        CHECK_THROWS( chunk -= right );
+        CHECK_THROWS( result = chunk + right );
+        CHECK_THROWS( result = chunk - right );
+      } // THEN
+
+      THEN( "a TabulatedAverageEnergy can be linearised" ) {
+
+        TabulatedAverageEnergy linear = chunk.linearise();
+
+        CHECK( 12 == linear.numberPoints() );
+        CHECK( 2 == linear.numberRegions() );
+
+        CHECK( 12 == linear.energies().size() );
+        CHECK( 12 == linear.values().size() );
+        CHECK( 2 == linear.boundaries().size() );
+        CHECK( 2 == linear.interpolants().size() );
+
+        CHECK(  1 == linear.boundaries()[0] );
+        CHECK( 11 == linear.boundaries()[1] );
+
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[0] );
+        CHECK( InterpolationType::LinearLinear == linear.interpolants()[1] );
+
+        CHECK_THAT( 1.   , WithinRel( linear.energies()[0] ) );
+        CHECK_THAT( 2.   , WithinRel( linear.energies()[1] ) );
+        CHECK_THAT( 2.   , WithinRel( linear.energies()[2] ) );
+        CHECK_THAT( 2.125, WithinRel( linear.energies()[3] ) );
+        CHECK_THAT( 2.25 , WithinRel( linear.energies()[4] ) );
+        CHECK_THAT( 2.5  , WithinRel( linear.energies()[5] ) );
+        CHECK_THAT( 2.75 , WithinRel( linear.energies()[6] ) );
+        CHECK_THAT( 3.   , WithinRel( linear.energies()[7] ) );
+        CHECK_THAT( 3.25 , WithinRel( linear.energies()[8] ) );
+        CHECK_THAT( 3.5  , WithinRel( linear.energies()[9] ) );
+        CHECK_THAT( 3.75 , WithinRel( linear.energies()[10] ) );
+        CHECK_THAT( 4.   , WithinRel( linear.energies()[11] ) );
+
+        CHECK_THAT( 4.              , WithinRel( linear.values()[0] ) );
+        CHECK_THAT( 3.              , WithinRel( linear.values()[1] ) );
+        CHECK_THAT( 4.              , WithinRel( linear.values()[2] ) );
+        CHECK_THAT( 3.85048128530886, WithinRel( linear.values()[3] ) );
+        CHECK_THAT( 3.70951129135145, WithinRel( linear.values()[4] ) );
+        CHECK_THAT( 3.44966028678679, WithinRel( linear.values()[5] ) );
+        CHECK_THAT( 3.21459646033567, WithinRel( linear.values()[6] ) );
+        CHECK_THAT( 3.              , WithinRel( linear.values()[7] ) );
+        CHECK_THAT( 2.72176678584324, WithinRel( linear.values()[8] ) );
+        CHECK_THAT( 2.46416306545103, WithinRel( linear.values()[9] ) );
+        CHECK_THAT( 2.22433973930853, WithinRel( linear.values()[10] ) );
+        CHECK_THAT( 2.              , WithinRel( linear.values()[11] ) );
+
+        CHECK( true == linear.isLinearised() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "non-linearised data with multiple regions with a jump and boundaries "
+         "that point to the second x value in the jump" ) {
+
+    // note: at construction time, the boundary value will be set to the first point in
+    //       the jump. As a result, the final data contained in this InterpolationTable is the
+    //       same as the previous test.
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > x = { 1., 2., 2., 3., 4. };
+      const std::vector< double > y = { 4., 3., 4., 3., 2. };
+      const std::vector< std::size_t > boundaries = { 2, 4 }; // <-- pointing to end of the jump
+      const std::vector< InterpolationType > interpolants = {
+
+        InterpolationType::LinearLinear,
+        InterpolationType::LinearLog
+      };
+
+      TabulatedAverageEnergy chunk( std::move( x ), std::move( y ),
+                                          std::move( boundaries ),
+                                          std::move( interpolants ) );
+
+      THEN( "a InterpolationTable can be constructed and members can be tested" ) {
+
+        CHECK( 5 == chunk.energies().size() );
+        CHECK( 5 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[3] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[4] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 4., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[3] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[4] ) );
+        CHECK( 1 == chunk.boundaries()[0] );           // <-- this is changed from 2 to 1
+        CHECK( 4 == chunk.boundaries()[1] );
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLog == chunk.interpolants()[1] );
+        CHECK( false == chunk.isLinearised() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "non-linearised data with multiple regions with a jump at the end that goes to zero" ) {
+
+    // note: at construction time, the last x and y value will be removed and the last
+    //       boundary value will be decremented by 1.
+
+    WHEN( "the data is given explicitly" ) {
+
+      const std::vector< double > x = { 1., 2., 3., 4., 4. }; // <-- jump at end
+      const std::vector< double > y = { 4., 3., 2., 1., 0. }; // <-- last value is zero
+      const std::vector< std::size_t > boundaries = { 1, 4 }; // <-- pointing to end
+      const std::vector< InterpolationType > interpolants = {
+
+        InterpolationType::LinearLinear,
+        InterpolationType::LinearLog
+      };
+
+      TabulatedAverageEnergy chunk( std::move( x ), std::move( y ),
+                                   std::move( boundaries ),
+                                   std::move( interpolants ) );
+
+      THEN( "an InterpolationTable can be constructed and members can be tested" ) {
+
+        CHECK( 4 == chunk.numberPoints() );
+        CHECK( 2 == chunk.numberRegions() );
+        CHECK( 4 == chunk.energies().size() );
+        CHECK( 4 == chunk.values().size() );
+        CHECK( 2 == chunk.boundaries().size() );
+        CHECK( 2 == chunk.interpolants().size() );
+        CHECK_THAT( 1., WithinRel( chunk.energies()[0] ) );
+        CHECK_THAT( 2., WithinRel( chunk.energies()[1] ) );
+        CHECK_THAT( 3., WithinRel( chunk.energies()[2] ) );
+        CHECK_THAT( 4., WithinRel( chunk.energies()[3] ) ); // <-- last point removed
+        CHECK_THAT( 4., WithinRel( chunk.values()[0] ) );
+        CHECK_THAT( 3., WithinRel( chunk.values()[1] ) );
+        CHECK_THAT( 2., WithinRel( chunk.values()[2] ) );
+        CHECK_THAT( 1., WithinRel( chunk.values()[3] ) ); // <-- last point removed
+        CHECK( 1 == chunk.boundaries()[0] );
+        CHECK( 3 == chunk.boundaries()[1] );         // <-- boundary value reset
+        CHECK( InterpolationType::LinearLinear == chunk.interpolants()[0] );
+        CHECK( InterpolationType::LinearLog == chunk.interpolants()[1] );
+        CHECK( false == chunk.isLinearised() );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+
+  GIVEN( "invalid data for an InterpolationTable object" ) {
+
+    WHEN( "there are not enough values in the x or y grid" ) {
+
+      std::vector< double > empty = {};
+      std::vector< double > one = { 1. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( empty, empty ) );
+        CHECK_THROWS( TabulatedAverageEnergy( one, one ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x and y grid do not have the same number of points" ) {
+
+      std::vector< double > x = { 1., 2., 3., 4. };
+      std::vector< double > y = { 4., 3., 2. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the boundaries and interpolants do not have the same size" ) {
+
+      std::vector< double > x = { 1., 2., 3., 4. };
+      std::vector< double > y = { 4., 3., 2., 1. };
+      std::vector< std::size_t > boundaries = { 3 };
+      std::vector< InterpolationType > interpolants = {};
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ),
+                                             std::move( boundaries ),
+                                             std::move( interpolants ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x grid is not sorted" ) {
+
+      std::vector< double > x = { 1., 3., 2., 4. };
+      std::vector< double > y = { 4., 3., 2., 1. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x grid contains a triple x value" ) {
+
+      std::vector< double > x = { 1., 2., 2., 2., 3., 4. };
+      std::vector< double > y = { 4., 3., 3., 3., 2., 1. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x grid has a jump at the beginning" ) {
+
+      std::vector< double > x = { 1., 1., 3., 4. };
+      std::vector< double > y = { 4., 3., 1., 4. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the x grid has a jump at the end" ) {
+
+      std::vector< double > x = { 1., 2., 4., 4. };
+      std::vector< double > y = { 4., 3., 1., 4. };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ) ) );
+      } // THEN
+    } // WHEN
+
+    WHEN( "the last boundary does not point to the last point" ) {
+
+      std::vector< double > x = { 1., 2., 4., 4. };
+      std::vector< double > y = { 4., 3., 1., 4. };
+      std::vector< std::size_t > boundaries = { 2 };
+      std::vector< InterpolationType > interpolants = { InterpolationType::LinearLinear };
+
+      THEN( "an exception is thrown" ) {
+
+        CHECK_THROWS( TabulatedAverageEnergy( std::move( x ), std::move( y ),
+                                             std::move( boundaries ),
+                                             std::move( interpolants ) ) );
+      } // THEN
+    } // WHEN
+  } // GIVEN
+} // SCENARIO


### PR DESCRIPTION
This adds and integrates TabulatedAverageEnergy for a ReactionProduct.

The average reaction product energy will be useful for when we calculate heating numbers. It is also used as an alternative to LAW = 8 from MF26. LAW = 8 is the average energy transfer in an electro-atomic excitation event, and the average outgoing electron energy is simply equal to the incident energy of the electron minus the average energy transfer.

With a modernised NJOY, we want to make these average energy values available to users on a by reaction product basis, both on the ReactionProduct and the ProjectTarget level due to their potential usefulness to users.