### PR TITLE
Extending scattering functions in photoatomic data

### DIFF
--- a/python/src/TabulatedScatteringFunction.python.cpp
+++ b/python/src/TabulatedScatteringFunction.python.cpp
@@ -83,16 +83,38 @@ void wrapTabulatedScatteringFunction( python::module& module, python::module& ) 
     &Component::upperInverseLengthLimit,
     "The upper inverse length limit"
   )
+  .def_property_readonly(
+
+    "inverse_length",
+    &Component::inverseLength,
+    "The inverse length value associated to an energy,cosine pair\n\n"
+    "Arguments:\n"
+    "    self     the table\n"
+    "    energy   the incident photon energy\n"
+    "    cosine   the coutgoing photon osine"
+  )
   .def(
 
     "__call__",
     [] ( const Component& self, double inverse_length ) -> decltype(auto)
        { return self( inverse_length ); },
     python::arg( "inverse_length" ),
-    "Evaluate the table for a given energy value\n\n"
+    "Evaluate the table for a given inverse length value\n\n"
     "Arguments:\n"
     "    self              the table\n"
     "    inverse_length    the inverse length value"
+  )
+  .def(
+
+    "__call__",
+    [] ( const Component& self, double energy, double cosine ) -> decltype(auto)
+       { return self( energy, cosine ); },
+    python::arg( "energy" ), python::arg( "cosine" ),
+    "Evaluate the table for a given energy,cosine pair\n\n"
+    "Arguments:\n"
+    "    self     the table\n"
+    "    energy   the incident photon energy\n"
+    "    cosine   the coutgoing photon osine"
   );
 
   // add standard tabulated data definitions

--- a/src/dryad/TabulatedScatteringFunction.hpp
+++ b/src/dryad/TabulatedScatteringFunction.hpp
@@ -62,16 +62,23 @@ namespace dryad {
       return this->x().back();
     }
 
-//! @todo add physical constants to scion or dryad
-//    /**
-//     *  @brief Return the inverse length value associated to an energy,cosine pair
-//     */
-//    double inverseLength( double energy, double cosine ) const noexcept {
-//
-//      double h = ;
-//      double c = ;
-//      return energy / h / c * std::sqrt( 0.5 * ( 1 - cosine ) );
-//    }
+    /**
+     *  @brief Return the inverse length value associated to an energy,cosine pair
+     *
+     *  @param energy   the incident photon energy
+     *  @param cosine   the outgoing photon cosine
+     */
+    double inverseLength( double energy, double cosine ) const noexcept {
+
+      //! @todo add physical constants to scion or dryad
+
+      const double h = 6.62607015e-34;       // Planck constant, unit: J s
+      const double c = 299792458;            // light speed, unit: m / s
+      const double e = 1.602176634e-19;      // elementary charge, unit: C
+      const double a = 1e-10;                // angstrom, unit: m
+      const double constant = a * e / h / c; // units: 1 / eV / angstrom
+      return constant * energy * std::sqrt( 0.5 * ( 1 - cosine ) );
+    }
 
     using InterpolationTable::boundaries;
     using InterpolationTable::interpolants;
@@ -80,6 +87,17 @@ namespace dryad {
     using InterpolationTable::isLinearised;
 
     using InterpolationTable::operator();
+
+    /**
+     *  @brief Evaluate the scattering function for an energy,cosine pair
+     *
+     *  @param energy   the incident photon energy
+     *  @param cosine   the outgoing photon cosine
+     */
+    double operator()( double energy, double cosine ) const {
+
+      return this->operator()( this->inverseLength( energy, cosine ) );
+    }
 
     /**
      *  @brief Return a linearised scattering function table


### PR DESCRIPTION
This PR extends the interface for the tabulated scattering function in the photoatomic data, used for coherent an incoherent scattering.

This data is given as a tabulated function of inverse length, given in inverse Angstrom. This is inverse length is a function of the incident photon energy and the outgoing photon's cosine. This PR adds a method to calculate the inverse length for an energy,cosine pair and a call operator to evaluate the table for an energy cosine pair.